### PR TITLE
Replica calls now include version id

### DIFF
--- a/log/client/ReplicaClient.h
+++ b/log/client/ReplicaClient.h
@@ -16,12 +16,12 @@ class ReplicaClient {
   explicit ReplicaClient(std::shared_ptr<grpc::Channel> channel);
 
   folly::SemiFuture<std::string> getId();
-  folly::SemiFuture<folly::Unit> append(LogId logId,
+  folly::SemiFuture<folly::Unit> append(VersionId versionId, LogId logId,
                                         std::string logEntryPayload,
                                         bool skipSeal);
   folly::SemiFuture<std::variant<LogEntry, LogReadError>>
-  getLogEntry(LogId logId);
-  folly::SemiFuture<LogId> getLocalCommitIndex();
+  getLogEntry(VersionId versionId, LogId logId);
+  folly::SemiFuture<LogId> getLocalCommitIndex(VersionId versionId);
   folly::SemiFuture<LogId> seal(VersionId versionId);
 
  private:

--- a/log/impl/InMemoryMetadataStore.cc
+++ b/log/impl/InMemoryMetadataStore.cc
@@ -88,7 +88,7 @@ void InMemoryMetadataStore::compareAndAppendRange(VersionId versionId,
       && lastConfig->first + 1 == newMetadataConfig.version_id()) {
     // Now we have an implicit contract that the new index is 1 greater than
     // last config index.
-    state_->configs_[versionId].set_end_index(newMetadataConfig.previous_version_end_index());
+    state_->configs_[versionId].set_end_index(newMetadataConfig.start_index());
     state_->configs_[newMetadataConfig.version_id()] = newMetadataConfig;
     state_->logIdToConfig_[newMetadataConfig.start_index()] =
         newMetadataConfig;

--- a/log/impl/NanoLogStoreImpl.h
+++ b/log/impl/NanoLogStoreImpl.h
@@ -2,9 +2,9 @@
 // Created by Rahul  Kushwaha on 1/2/23.
 //
 
-#ifndef LOGSTORAGE_NANOLOGSTOREIMPL_H
-#define LOGSTORAGE_NANOLOGSTOREIMPL_H
-#include "../include/NanoLogStore.h"
+#pragma once
+
+#include "log/include/NanoLogStore.h"
 #include <unordered_map>
 
 namespace rk::projects::durable_log {
@@ -21,5 +21,3 @@ class NanoLogStoreImpl: public NanoLogStore {
 };
 
 }
-
-#endif //LOGSTORAGE_NANOLOGSTOREIMPL_H

--- a/log/impl/NullSequencer.h
+++ b/log/impl/NullSequencer.h
@@ -27,7 +27,7 @@ class NullSequencer: public Sequencer {
     throw NullSequencerException{};
   }
 
-  void start(LogId sequenceNum) override {
+  void start(VersionId versionId, LogId sequenceNum) override {
     throw NullSequencerException{};
   }
 

--- a/log/impl/RemoteReplica.h
+++ b/log/impl/RemoteReplica.h
@@ -23,17 +23,23 @@ class RemoteReplica final: public Replica {
   }
 
   folly::SemiFuture<folly::Unit>
-  append(LogId logId, std::string logEntryPayload, bool skipSeal) override {
-    return replicaClient_->append(logId, std::move(logEntryPayload), skipSeal);
+  append(VersionId versionId,
+         LogId logId,
+         std::string logEntryPayload,
+         bool skipSeal) override {
+    return replicaClient_->append(versionId,
+                                  logId,
+                                  std::move(logEntryPayload),
+                                  skipSeal);
   }
 
   folly::SemiFuture<std::variant<LogEntry, LogReadError>>
-  getLogEntry(LogId logId) override {
-    return replicaClient_->getLogEntry(logId);
+  getLogEntry(VersionId versionId, LogId logId) override {
+    return replicaClient_->getLogEntry(versionId, logId);
   }
 
-  LogId getLocalCommitIndex() override {
-    return replicaClient_->getLocalCommitIndex().get();
+  LogId getLocalCommitIndex(VersionId versionId) override {
+    return replicaClient_->getLocalCommitIndex(versionId).get();
   }
 
   LogId seal(VersionId versionId) override {

--- a/log/impl/RemoteSequencer.h
+++ b/log/impl/RemoteSequencer.h
@@ -27,7 +27,7 @@ class RemoteSequencer final: public Sequencer {
     return sequencerClient_->latestAppendPosition();
   }
 
-  void start(LogId sequenceNum) override {
+  void start(VersionId versionId, LogId sequenceNum) override {
     throw NotImplementedException{};
   }
 

--- a/log/impl/ReplicaImpl.h
+++ b/log/impl/ReplicaImpl.h
@@ -23,14 +23,14 @@ class ReplicaImpl: public Replica {
   std::string getName() override;
 
   folly::SemiFuture<folly::Unit>
-  append(LogId logId,
+  append(VersionId versionId, LogId logId,
          std::string logEntryPayload,
          bool skipSeal = false) override;
 
   folly::SemiFuture<std::variant<LogEntry, LogReadError>>
-  getLogEntry(LogId logId) override;
+  getLogEntry(VersionId versionId, LogId logId) override;
 
-  LogId getLocalCommitIndex() override;
+  LogId getLocalCommitIndex(VersionId versionId) override;
 
   LogId seal(VersionId versionId) override;
 

--- a/log/impl/SequencerImpl.h
+++ b/log/impl/SequencerImpl.h
@@ -16,13 +16,14 @@ class SequencerImpl: public Sequencer {
   explicit SequencerImpl(std::string id,
                          std::vector<std::shared_ptr<Replica>> replicaSet,
                          LogId seedSeqNum,
+                         VersionId versionId,
                          bool isAlive = false);
 
  public:
   std::string getId() override;
   folly::SemiFuture<LogId> append(std::string logEntryPayload) override;
   folly::SemiFuture<LogId> latestAppendPosition() override;
-  void start(LogId sequenceNum) override;
+  void start(VersionId versionId, LogId sequenceNum) override;
   bool isAlive() override;
   void stop() override;
   ~SequencerImpl() override = default;
@@ -31,6 +32,7 @@ class SequencerImpl: public Sequencer {
   std::string id_;
   std::vector<std::shared_ptr<Replica>> replicaSet_;
   std::atomic<LogId> sequenceNum_;
+  VersionId versionId_;
   std::int32_t quorumSize_;
   std::atomic_bool isAlive_;
 };

--- a/log/impl/VectorBasedNanoLog.h
+++ b/log/impl/VectorBasedNanoLog.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "../include/NanoLog.h"
-#include "../utils/OrderedCompletionQueue.h"
+#include "log/include/NanoLog.h"
+#include "log/utils/OrderedCompletionQueue.h"
 #include <map>
 
 namespace rk::projects::durable_log {

--- a/log/impl/VirtualLogFactory.cc
+++ b/log/impl/VirtualLogFactory.cc
@@ -73,7 +73,10 @@ makeReplica(std::string id,
 std::unique_ptr<Sequencer>
 makeSequencer(std::string sequencerId,
               std::vector<std::shared_ptr<Replica>> replicaSet) {
-  return std::make_unique<SequencerImpl>(sequencerId, std::move(replicaSet), 1);
+  return std::make_unique<SequencerImpl>(sequencerId,
+                                         std::move(replicaSet),
+                                         1,
+                                         1);
 }
 
 std::unique_ptr<Registry> makeRegistry() {

--- a/log/impl/tests/MockReplica.h
+++ b/log/impl/tests/MockReplica.h
@@ -15,14 +15,14 @@ class MockReplica: public Replica {
 
   MOCK_METHOD(folly::SemiFuture<folly::Unit>,
               append,
-              (LogId logId, std::string logEntryPayload, bool skipSeal),
+              (VersionId versionId, LogId logId, std::string logEntryPayload, bool skipSeal),
               (override));
 
   MOCK_METHOD((folly::SemiFuture<std::variant<LogEntry, LogReadError>>),
               getLogEntry,
-              (LogId logId), (override));
+              (VersionId versionId, LogId logId), (override));
 
-  MOCK_METHOD(LogId, getLocalCommitIndex, (), (override));
+  MOCK_METHOD(LogId, getLocalCommitIndex, (VersionId versionId), (override));
 
   MOCK_METHOD(LogId, seal, (VersionId versionId), (override));
 };

--- a/log/impl/tests/SequencerTest.cc
+++ b/log/impl/tests/SequencerTest.cc
@@ -13,12 +13,13 @@ TEST(SequencerTest, appendLogEntry) {
   auto sequencerCreationResult = createSequencer(0);
   auto sequencer = sequencerCreationResult.sequencer;
   auto replicaSet = sequencerCreationResult.replicaSet;
+  auto versionId = sequencerCreationResult.metadataStore->getCurrentVersionId();
 
   std::string logEntry{"Hello World"};
   ASSERT_EQ(sequencer->append(logEntry).get(), 1);
 
   for (auto &replica: replicaSet) {
-    auto result = replica->getLogEntry(1).get();
+    auto result = replica->getLogEntry(versionId, 1).get();
     ASSERT_TRUE(std::holds_alternative<LogEntry>(result));
     ASSERT_EQ(std::get<LogEntry>(result).logId, 1);
     ASSERT_EQ(std::get<LogEntry>(result).payload, logEntry);
@@ -30,12 +31,13 @@ TEST(SequencerTest, appendLogEntryWithMajorityFailing) {
   auto sequencer = sequencerCreationResult.sequencer;
   auto replicaSet = sequencerCreationResult.replicaSet;
   auto goodReplicaSet = sequencerCreationResult.goodReplicaSet;
+  auto versionId = sequencerCreationResult.metadataStore->getCurrentVersionId();
 
   std::string logEntry{"Hello World"};
   ASSERT_THROW(sequencer->append(logEntry).get(), std::exception);
 
   for (auto &replica: goodReplicaSet) {
-    auto result = replica->getLogEntry(1).get();
+    auto result = replica->getLogEntry(versionId, 1).get();
     ASSERT_TRUE(std::holds_alternative<LogEntry>(result));
     ASSERT_EQ(std::get<LogEntry>(result).logId, 1);
     ASSERT_EQ(std::get<LogEntry>(result).payload, logEntry);

--- a/log/impl/tests/TestUtils.h
+++ b/log/impl/tests/TestUtils.h
@@ -53,14 +53,14 @@ createSequencer(std::int32_t numberOfBadReplicas = 0,
           return "MOCK_REPLICA_" + utils::UuidGenerator::instance().generate();
         });
 
-    ON_CALL(*mockReplica, append(_, _, _))
+    ON_CALL(*mockReplica, append(_, _, _, _))
         .WillByDefault([]() {
           return folly::makeSemiFuture<folly::Unit>
               (folly::make_exception_wrapper<NonRecoverableError>(
                   NonRecoverableError{}));
         });
 
-    ON_CALL(*mockReplica, getLogEntry(_))
+    ON_CALL(*mockReplica, getLogEntry(_, _))
         .WillByDefault([]() {
           return folly::SemiFuture<std::variant<LogEntry, LogReadError>>
               (folly::make_exception_wrapper<NonRecoverableError>(
@@ -92,7 +92,8 @@ createSequencer(std::int32_t numberOfBadReplicas = 0,
       std::make_shared<SequencerImpl>(
           "SEQUENCER_" + utils::UuidGenerator::instance().generate(),
           replicaSet,
-          sequencerStartNum);
+          sequencerStartNum,
+          config.version_id());
   registry->registerSequencer(sequencer);
 
   config.mutable_sequencer_config()->set_id(sequencer->getId());

--- a/log/include/Common.h
+++ b/log/include/Common.h
@@ -10,6 +10,7 @@
 namespace rk::projects::durable_log {
 
 using LogId = std::int64_t;
+using VersionId = std::int64_t;
 
 constexpr LogId
     LowestNonExistingLogId = std::numeric_limits<std::int64_t>::min();
@@ -47,6 +48,13 @@ class NotImplementedException: public std::exception {
  public:
   const char *what() const _NOEXCEPT override {
     return "Method Not Implmented";
+  }
+};
+
+class MetadataBlockNotFound: public std::exception {
+ public:
+  const char *what() const _NOEXCEPT override {
+    return "metadatablock not found";
   }
 };
 

--- a/log/include/MetadataStore.h
+++ b/log/include/MetadataStore.h
@@ -11,7 +11,6 @@
 #include <optional>
 
 namespace rk::projects::durable_log {
-using VersionId = std::int64_t;
 
 struct OptimisticConcurrencyException: public std::exception {
   const char *what() const noexcept override {

--- a/log/include/Replica.h
+++ b/log/include/Replica.h
@@ -18,13 +18,13 @@ class Replica {
   virtual std::string getId() = 0;
   virtual std::string getName() = 0;
   virtual folly::SemiFuture<folly::Unit>
-  append(LogId logId,
+  append(VersionId versionId, LogId logId,
          std::string logEntryPayload,
          bool skipSeal = false) = 0;
   virtual folly::SemiFuture<std::variant<LogEntry, LogReadError>>
-  getLogEntry(LogId logId) = 0;
+  getLogEntry(VersionId versionId, LogId logId) = 0;
 
-  virtual LogId getLocalCommitIndex() = 0;
+  virtual LogId getLocalCommitIndex(VersionId versionId) = 0;
   virtual LogId seal(VersionId versionId) = 0;
 
   virtual ~Replica() = default;

--- a/log/include/Sequencer.h
+++ b/log/include/Sequencer.h
@@ -13,7 +13,7 @@ class Sequencer {
   virtual std::string getId() = 0;
   virtual folly::SemiFuture<LogId> append(std::string logEntryPayload) = 0;
   virtual folly::SemiFuture<LogId> latestAppendPosition() = 0;
-  virtual void start(LogId sequenceNum) = 0;
+  virtual void start(VersionId versionId, LogId sequenceNum) = 0;
   virtual bool isAlive() = 0;
   virtual void stop() = 0;
   virtual ~Sequencer() = default;

--- a/log/include/VirtualLog.h
+++ b/log/include/VirtualLog.h
@@ -15,9 +15,11 @@ class VirtualLog {
  public:
   virtual std::string getId() = 0;
   virtual std::string getName() = 0;
+
   virtual folly::SemiFuture<LogId> append(std::string logEntryPayload) = 0;
   virtual folly::SemiFuture<std::variant<LogEntry, LogReadError>>
   getLogEntry(LogId logId) = 0;
+
   virtual folly::coro::Task<MetadataConfig> getCurrentConfig() = 0;
   virtual folly::coro::Task<MetadataConfig>
   reconfigure(MetadataConfig metadataConfig) = 0;

--- a/log/server/ReplicaServer.cc
+++ b/log/server/ReplicaServer.cc
@@ -27,7 +27,8 @@ ReplicaServer::append(::grpc::ServerContext *context,
                       const server::ReplicaAppendRequest *request,
                       ::google::protobuf::Empty *response) {
   try {
-    replica_->append(request->log_id(),
+    replica_->append(request->version_id(),
+                     request->log_id(),
                      request->payload(),
                      request->skip_seal())
         .get();
@@ -43,7 +44,8 @@ ReplicaServer::getLogEntry(::grpc::ServerContext *context,
                            const server::GetLogEntryRequest *request,
                            server::GetLogEntryResponse *response) {
   try {
-    auto logEntryResponse = replica_->getLogEntry(request->log_id()).get();
+    auto logEntryResponse =
+        replica_->getLogEntry(request->version_id(), request->log_id()).get();
 
     if (std::holds_alternative<durable_log::LogEntry>(logEntryResponse)) {
       auto logEntry = std::get<durable_log::LogEntry>(logEntryResponse);
@@ -74,10 +76,10 @@ ReplicaServer::getLogEntry(::grpc::ServerContext *context,
 
 grpc::Status
 ReplicaServer::getLocalCommitIndex(::grpc::ServerContext *context,
-                                   const ::google::protobuf::Empty *request,
+                                   const server::GetLocalCommitIndexRequest *request,
                                    server::LogIdResponse *response) {
   try {
-    response->set_log_id(replica_->getLocalCommitIndex());
+    response->set_log_id(replica_->getLocalCommitIndex(request->version_id()));
   } catch (const std::exception &e) {
     return grpc::Status{grpc::StatusCode::UNKNOWN, e.what()};
   }

--- a/log/server/ReplicaServer.h
+++ b/log/server/ReplicaServer.h
@@ -24,7 +24,7 @@ class ReplicaServer final: public server::ReplicaService::Service {
                            const server::GetLogEntryRequest *request,
                            server::GetLogEntryResponse *response) override;
   grpc::Status getLocalCommitIndex(::grpc::ServerContext *context,
-                                   const ::google::protobuf::Empty *request,
+                                   const server::GetLocalCommitIndexRequest *request,
                                    server::LogIdResponse *response) override;
   grpc::Status seal(::grpc::ServerContext *context,
                     const server::SealRequest *request,

--- a/log/server/proto/Replica.proto
+++ b/log/server/proto/Replica.proto
@@ -12,22 +12,28 @@ service ReplicaService {
 
   rpc getLogEntry(GetLogEntryRequest)returns(GetLogEntryResponse){}
 
-  rpc getLocalCommitIndex(google.protobuf.Empty) returns (LogIdResponse){}
+  rpc getLocalCommitIndex(GetLocalCommitIndexRequest) returns (LogIdResponse){}
 
   rpc seal(SealRequest) returns (LogIdResponse){}
 }
 
 message GetLogEntryRequest{
-  int64  log_id = 1;
+  int64 version_id = 1;
+  int64  log_id = 2;
 }
 
 message ReplicaAppendRequest{
-  int64 log_id = 1;
-  string payload = 2;
-  bool skip_seal = 3;
+  int64 version_id = 1;
+  int64 log_id = 2;
+  string payload = 3;
+  bool skip_seal = 4;
 }
 
 message SealRequest{
+  int64 version_id = 1;
+}
+
+message GetLocalCommitIndexRequest{
   int64 version_id = 1;
 }
 


### PR DESCRIPTION
**Background**: Previously, replica did not take versionId in requests, and instead depended on finding the current versionId from the metadata store. Instead we wan to push the versionId from the sequencer. Sequencer/Virtual is the one that is aware of the `current` version and push it down to replica. 

**Implementation**: 
1. Change apis of the various components to accept versionId as one of the parameters. 

**Tests**: 
1. Update unittests.