### PR TITLE
Add in memory implementation of WriteOnceRegister

### DIFF
--- a/cmake/source_list.cmake
+++ b/cmake/source_list.cmake
@@ -66,4 +66,9 @@ set(
         log/utils/OrderedCompletionQueue.h
         log/utils/UuidGenerator.h
         metrics/MetricsRegistry.h
+
+        wor/include/WriteOnceRegister.h
+        wor/include/WriteOnceRegisterChain.h
+        wor/inmemory/InMemoryWriteOnceRegister.h
+        wor/inmemory/InMemoryWriteOnceRegisterChain.h
 )

--- a/cmake/test_files_list.cmake
+++ b/cmake/test_files_list.cmake
@@ -40,4 +40,6 @@ set(
 
         applications/counter/test/InMemoryFakeVirtualLog.h
         applications/counter/test/CounterAppTest.cc
+
+        wor/tests/InMemoryWriteOnceRegisterTest.cc
 )

--- a/wor/include/WriteOnceRegister.h
+++ b/wor/include/WriteOnceRegister.h
@@ -1,0 +1,26 @@
+//
+// Created by Rahul  Kushwaha on 6/3/23.
+//
+
+#pragma once
+#include <optional>
+#include <cstdint>
+#include <string>
+
+namespace rk::projects::wor {
+
+using LockId = std::int64_t;
+
+class WriteOnceRegister {
+ public:
+  enum class ReadError {
+    UNKNOWN,
+    NOT_WRITTEN,
+  };
+
+  virtual std::optional<LockId> lock() = 0;
+  virtual bool write(LockId lockId, std::string payload) = 0;
+  virtual std::variant<std::string, ReadError> read() = 0;
+};
+
+}

--- a/wor/include/WriteOnceRegisterChain.h
+++ b/wor/include/WriteOnceRegisterChain.h
@@ -1,0 +1,17 @@
+//
+// Created by Rahul  Kushwaha on 6/7/23.
+//
+#include "WriteOnceRegister.h"
+
+namespace rk::projects::wor {
+
+using WorId = std::int64_t;
+
+class WriteOnceRegisterChain {
+ public:
+  virtual std::optional<WorId> append() = 0;
+  virtual std::optional<std::shared_ptr<WriteOnceRegister>> get(WorId id) = 0;
+  virtual std::optional<WorId> tail() = 0;
+};
+
+}

--- a/wor/inmemory/InMemoryWriteOnceRegister.h
+++ b/wor/inmemory/InMemoryWriteOnceRegister.h
@@ -1,0 +1,49 @@
+//
+// Created by Rahul  Kushwaha on 6/7/23.
+//
+#include "wor/include/WriteOnceRegister.h"
+
+#include <memory>
+#include <mutex>
+
+namespace rk::projects::wor {
+class InMemoryWriteOnceRegister: public WriteOnceRegister {
+ public:
+  explicit InMemoryWriteOnceRegister()
+      : lockId_{0}, committed_{false},
+        payload_{},
+        mtx_{std::make_unique<std::mutex>()} {}
+
+  std::optional<LockId> lock() override {
+    std::lock_guard lg{*mtx_};
+    lockId_++;
+    return {lockId_};
+  }
+
+  bool write(LockId lockId, std::string payload) override {
+    std::lock_guard lg{*mtx_};
+    if (!committed_ && lockId == lockId_) {
+      payload_ = std::move(payload);
+      committed_ = true;
+      return true;
+    }
+
+    return false;
+  }
+
+  std::variant<std::string, ReadError> read() override {
+    if (committed_) {
+      return {payload_};
+    }
+
+    return {ReadError::NOT_WRITTEN};
+  }
+
+ private:
+  LockId lockId_;
+  bool committed_;
+  std::string payload_;
+  std::unique_ptr<std::mutex> mtx_;
+};
+
+}

--- a/wor/inmemory/InMemoryWriteOnceRegisterChain.h
+++ b/wor/inmemory/InMemoryWriteOnceRegisterChain.h
@@ -1,0 +1,52 @@
+//
+// Created by Rahul  Kushwaha on 6/7/23.
+//
+
+#pragma once
+#include "wor/include/WriteOnceRegisterChain.h"
+#include "wor/inmemory/InMemoryWriteOnceRegister.h"
+
+#include <atomic>
+#include <map>
+#include <mutex>
+
+namespace rk::projects::wor {
+
+class InMemoryWriteOnceRegisterChain: public WriteOnceRegisterChain {
+ public:
+  std::optional<WorId> append() override {
+    std::lock_guard lg{*mtx_};
+
+    worId_++;
+    auto wor = std::make_shared<InMemoryWriteOnceRegister>();
+    lookup_.emplace(worId_, wor);
+    return {worId_};
+  }
+
+  std::optional<std::shared_ptr<WriteOnceRegister>> get(WorId id) override {
+    std::lock_guard lg{*mtx_};
+
+    auto itr = lookup_.find(id);
+    if (itr == lookup_.end()) {
+      return itr->second;
+    }
+
+    return {};
+  }
+
+  std::optional<WorId> tail() override {
+    std::lock_guard lg{*mtx_};
+    if (worId_ == 0) {
+      return {};
+    }
+
+    return {worId_};
+  }
+
+ private:
+  WorId worId_;
+  std::map<WorId, std::shared_ptr<WriteOnceRegister>> lookup_;
+  std::unique_ptr<std::mutex> mtx_;
+};
+
+}

--- a/wor/tests/InMemoryWriteOnceRegisterTest.cc
+++ b/wor/tests/InMemoryWriteOnceRegisterTest.cc
@@ -1,0 +1,92 @@
+//
+// Created by Rahul  Kushwaha on 6/7/23.
+//
+
+#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <vector>
+#include "wor/inmemory/InMemoryWriteOnceRegister.h"
+
+namespace rk::projects::wor {
+
+TEST(InMemoryWriteOnceRegisterTests, LockIdsAreIncreme) {
+  auto wor = InMemoryWriteOnceRegister{};
+
+  std::vector<LockId> lockIds;
+  for (int i = 0; i < 100; i++) {
+    auto lockId = wor.lock();
+    ASSERT_TRUE(lockId.has_value());
+    lockIds.emplace_back(lockId.value());
+  }
+
+  ASSERT_TRUE(std::is_sorted(lockIds.begin(), lockIds.end()));
+}
+
+TEST(InMemoryWriteOnceRegisterTests, ReadFromUnCommittedReturnsError) {
+  auto wor = InMemoryWriteOnceRegister{};
+  auto result = wor.read();
+
+  ASSERT_TRUE(std::holds_alternative<WriteOnceRegister::ReadError>(result));
+
+  auto readError = std::get<WriteOnceRegister::ReadError>(result);
+  ASSERT_EQ(WriteOnceRegister::ReadError::NOT_WRITTEN, readError);
+}
+
+TEST(InMemoryWriteOnceRegisterTests, WriteWithHigherLockValueSucceeds) {
+  auto wor = InMemoryWriteOnceRegister{};
+
+  // Acquire a bunch of locks.
+  std::vector<LockId> lockIds;
+  for (int i = 0; i < 100; i++) {
+    auto lockId = wor.lock();
+    ASSERT_TRUE(lockId.has_value());
+    lockIds.emplace_back(lockId.value());
+  }
+
+  auto lockId = wor.lock();
+  ASSERT_TRUE(lockId.has_value());
+
+  // All the locks acquired previously should fail.
+  for (auto prevLockId: lockIds) {
+    auto writeResult = wor.write(prevLockId, "Hello World");
+    ASSERT_FALSE(writeResult);
+
+    auto readResult = wor.read();
+    ASSERT_TRUE(std::holds_alternative<WriteOnceRegister::ReadError>(readResult));
+
+    auto readError = std::get<WriteOnceRegister::ReadError>(readResult);
+    ASSERT_EQ(WriteOnceRegister::ReadError::NOT_WRITTEN, readError);
+  }
+
+  auto result = wor.write(lockId.value(), "Hello World 1");
+  ASSERT_TRUE(result);
+
+  ASSERT_EQ("Hello World 1", std::get<std::string>(wor.read()));
+}
+
+TEST(InMemoryWriteOnceRegisterTests, WriteIsAllowedOnlyOnce) {
+  auto payload{"Hello World"};
+  auto wor = InMemoryWriteOnceRegister();
+  auto lockId = wor.lock();
+  ASSERT_TRUE(lockId.has_value());
+
+  auto result = wor.write(lockId.value(), payload);
+  ASSERT_TRUE(result);
+
+  ASSERT_EQ(payload, std::get<std::string>(wor.read()));
+
+  // Try writing it multiple times, and the result should be the same every time.
+  for (int i = 0; i < 100; i++) {
+    auto newPayload = fmt::format("Hello World {}", i);
+
+    lockId = wor.lock();
+    ASSERT_TRUE(lockId.has_value());
+
+    result = wor.write(lockId.value(), newPayload);
+    ASSERT_FALSE(result);
+
+    ASSERT_EQ(payload, std::get<std::string>(wor.read()));
+  }
+}
+
+}


### PR DESCRIPTION
**Background**: WriteOnceRegister is a good abstraction for Paxos. Once we are able to provide an in-memory implementation of WriteOnceRegister, writing Paxos should can be eased by leveraging the tests 

**Implementation**: 
1. Create an in-memory implementation of WriteOnceRegister. 
2. Create interface for WriteOnceRegisterChain. 

**Tests**: 
1. Unittests for InMemoryWriteOnceRegister.