### PR TITLE
Add persistence to Paxos

### DIFF
--- a/persistence/RocksDbFactory.h
+++ b/persistence/RocksDbFactory.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "fmt/format.h"
+#include "glog/logging.h"
 #include "rocksdb/db.h"
 
 namespace rk::projects::persistence {

--- a/persistence/RocksKVStoreLite.h
+++ b/persistence/RocksKVStoreLite.h
@@ -32,7 +32,11 @@ public:
       co_return value;
     }
 
-    co_return {};
+    if (status.IsNotFound()) {
+      co_return {};
+    }
+
+    throw std::runtime_error{status.ToString()};
   }
 
   folly::coro::Task<bool> putIfNotExists(std::string key,

--- a/wor/paxos/LocalAcceptor.cc
+++ b/wor/paxos/LocalAcceptor.cc
@@ -6,25 +6,33 @@
 
 namespace rk::projects::paxos {
 
-LocalAcceptor::LocalAcceptor(std::string id)
-    : id_{std::move(id)}, paxosInstance_{} {
-  paxosInstance_.mutable_promised_ballot_id()->set_major_id(-1);
-  paxosInstance_.mutable_promised_ballot_id()->set_minor_id(-1);
-  paxosInstance_.set_committed(false);
-}
+LocalAcceptor::LocalAcceptor(std::string id,
+                             std::shared_ptr<persistence::KVStoreLite> kvStore)
+    : id_{std::move(id)}, kvStore_{std::move(kvStore)},
+      mtx_{std::make_unique<std::mutex>()} {}
 
 std::string LocalAcceptor::getId() { return id_; }
 
 coro<std::variant<Promise, std::false_type>>
-LocalAcceptor::prepare(Ballot ballot) {
-  if (ballot.id <= paxosInstance_.promised_ballot_id()) {
+LocalAcceptor::prepare(std::string paxosInstanceId, Ballot ballot) {
+  std::lock_guard lk{*mtx_};
+
+  auto paxosInstance = co_await getOrCreate(paxosInstanceId);
+  if (ballot.id <= paxosInstance.promised_ballot_id()) {
     co_return std::false_type{};
   }
 
-  paxosInstance_.mutable_promised_ballot_id()->CopyFrom(ballot.id);
+  paxosInstance.mutable_promised_ballot_id()->CopyFrom(ballot.id);
+  bool result =
+      co_await kvStore_->put(fmt::format(KEY_FORMAT, paxosInstance.id()),
+                             paxosInstance.SerializeAsString());
 
-  if (paxosInstance_.has_accepted()) {
-    co_return paxosInstance_.accepted();
+  if (!result) {
+    throw std::runtime_error{"storage write failed"};
+  }
+
+  if (paxosInstance.has_accepted()) {
+    co_return paxosInstance.accepted();
   }
 
   Promise promise{};
@@ -32,38 +40,104 @@ LocalAcceptor::prepare(Ballot ballot) {
   co_return promise;
 }
 
-coro<bool> LocalAcceptor::accept(Proposal proposal) {
-  if (proposal.ballot_id() < paxosInstance_.promised_ballot_id()) {
+coro<bool> LocalAcceptor::accept(std::string paxosInstanceId,
+                                 Proposal proposal) {
+  std::lock_guard lk{*mtx_};
+
+  auto paxosInstance = co_await getOrCreate(paxosInstanceId);
+
+  if (proposal.ballot_id() < paxosInstance.promised_ballot_id()) {
     co_return false;
   }
 
-  paxosInstance_.mutable_promised_ballot_id()->CopyFrom(proposal.ballot_id());
+  paxosInstance.mutable_promised_ballot_id()->CopyFrom(proposal.ballot_id());
 
-  paxosInstance_.mutable_accepted()->mutable_ballot_id()->CopyFrom(
+  paxosInstance.mutable_accepted()->mutable_ballot_id()->CopyFrom(
       proposal.ballot_id());
-  paxosInstance_.mutable_accepted()->set_value(proposal.value());
+  paxosInstance.mutable_accepted()->set_value(proposal.value());
+
+  bool result =
+      co_await kvStore_->put(fmt::format(KEY_FORMAT, paxosInstance.id()),
+                             paxosInstance.SerializeAsString());
+
+  if (!result) {
+    throw std::runtime_error{"storage write failed"};
+  }
+
   co_return true;
 }
 
-coro<bool> LocalAcceptor::commit(BallotId ballotId) {
-  if (!paxosInstance_.committed()) {
-    paxosInstance_.set_committed(true);
+coro<bool> LocalAcceptor::commit(std::string paxosInstanceId,
+                                 BallotId ballotId) {
+  std::lock_guard lk{*mtx_};
+
+  auto paxosInstance = co_await getOrCreate(paxosInstanceId);
+
+  if (!paxosInstance.committed()) {
+    paxosInstance.set_committed(true);
+
+    bool result =
+        co_await kvStore_->put(fmt::format(KEY_FORMAT, paxosInstance.id()),
+                               paxosInstance.SerializeAsString());
+
+    if (!result) {
+      throw std::runtime_error{"storage write failed"};
+    }
+
     co_return true;
   }
 
   co_return false;
 }
 
-coro<std::optional<Promise>> LocalAcceptor::getAcceptedValue() {
-  co_return paxosInstance_.accepted();
+coro<std::optional<Promise>>
+LocalAcceptor::getAcceptedValue(std::string paxosInstanceId) {
+  std::lock_guard lk{*mtx_};
+
+  auto paxosInstance = co_await getOrCreate(paxosInstanceId);
+  co_return paxosInstance.accepted();
 }
 
-coro<std::optional<std::string>> LocalAcceptor::getCommittedValue() {
-  if (paxosInstance_.committed()) {
-    co_return paxosInstance_.accepted().value();
+coro<std::optional<std::string>>
+LocalAcceptor::getCommittedValue(std::string paxosInstanceId) {
+  std::lock_guard lk{*mtx_};
+
+  auto paxosInstance = co_await getOrCreate(paxosInstanceId);
+  if (paxosInstance.committed()) {
+    co_return paxosInstance.accepted().value();
   }
 
   co_return {};
+}
+
+coro<internal::PaxosInstance> LocalAcceptor::getOrCreate(std::string id) {
+  std::optional<std::string> result =
+      co_await kvStore_->get(fmt::format(KEY_FORMAT, id));
+  if (result.has_value()) {
+    internal::PaxosInstance paxosInstance{};
+    bool parseResult = paxosInstance.ParseFromString(result.value());
+
+    if (!parseResult) {
+      throw std::runtime_error{"paxos instance could not be deserialized"};
+    }
+
+    co_return paxosInstance;
+  }
+
+  internal::PaxosInstance paxosInstance{};
+  paxosInstance.set_id(id);
+  paxosInstance.mutable_promised_ballot_id()->set_major_id(-1);
+  paxosInstance.mutable_promised_ballot_id()->set_minor_id(-1);
+  paxosInstance.set_committed(false);
+
+  auto putResult = co_await kvStore_->put(fmt::format(KEY_FORMAT, id),
+                                          paxosInstance.SerializeAsString());
+
+  if (!putResult) {
+    throw std::runtime_error{"storage error"};
+  }
+
+  co_return paxosInstance;
 }
 
 } // namespace rk::projects::paxos

--- a/wor/paxos/PaxosWriteOnceRegister.h
+++ b/wor/paxos/PaxosWriteOnceRegister.h
@@ -11,8 +11,9 @@ namespace rk::projects::paxos {
 
 class PaxosWriteOnceRegister : public wor::WriteOnceRegister {
 public:
-  explicit PaxosWriteOnceRegister(std::shared_ptr<Proposer> proposer)
-      : majorId_{99}, lockId_{0}, proposer_{std::move(proposer)} {}
+  explicit PaxosWriteOnceRegister(std::shared_ptr<Proposer> proposer,
+                                  std::int32_t majorId)
+      : majorId_{majorId}, lockId_{0}, proposer_{std::move(proposer)} {}
 
   std::optional<wor::LockId> lock() override {
     auto lockId = getNextLockId();

--- a/wor/paxos/include/Acceptor.h
+++ b/wor/paxos/include/Acceptor.h
@@ -16,12 +16,14 @@ public:
   virtual std::string getId() = 0;
 
   virtual coro<std::variant<Promise, std::false_type>>
-  prepare(Ballot ballot) = 0;
-  virtual coro<bool> accept(Proposal proposal) = 0;
-  virtual coro<bool> commit(BallotId ballotId) = 0;
+  prepare(std::string paxosInstanceId, Ballot ballot) = 0;
+  virtual coro<bool> accept(std::string paxosInstanceId, Proposal proposal) = 0;
+  virtual coro<bool> commit(std::string paxosInstanceId, BallotId ballotId) = 0;
 
-  virtual coro<std::optional<Promise>> getAcceptedValue() = 0;
-  virtual coro<std::optional<std::string>> getCommittedValue() = 0;
+  virtual coro<std::optional<Promise>>
+  getAcceptedValue(std::string paxosInstanceId) = 0;
+  virtual coro<std::optional<std::string>>
+  getCommittedValue(std::string paxosInstanceId) = 0;
 };
 
 } // namespace rk::projects::paxos

--- a/wor/paxos/tests/AcceptorTests.cc
+++ b/wor/paxos/tests/AcceptorTests.cc
@@ -1,10 +1,25 @@
 //
 // Created by Rahul  Kushwaha on 6/12/23.
 //
+#include "persistence/RocksDbFactory.h"
+#include "persistence/RocksKVStoreLite.h"
 #include "wor/paxos/LocalAcceptor.h"
 #include <gtest/gtest.h>
 
 namespace rk::projects::paxos {
+
+class AcceptorTests : public testing::TestWithParam<std::string> {
+protected:
+  std::shared_ptr<persistence::KVStoreLite> kvStore_;
+  persistence::RocksDbFactory::RocksDbConfig config_{.path = "/tmp/paxos_tests",
+                                                     .createIfMissing = true};
+
+  void SetUp() override {
+    auto rocks = persistence::RocksDbFactory::provideSharedPtr(config_);
+    kvStore_ =
+        std::make_shared<persistence::RocksKVStoreLite>(std::move(rocks));
+  }
+};
 
 Ballot getNewBallot(std::int64_t id) {
   Ballot ballot{};
@@ -13,41 +28,48 @@ Ballot getNewBallot(std::int64_t id) {
   return ballot;
 }
 
-TEST(AcceptorTests, PrepareReturnsEmptyPromiseIfNotInitialized) {
-  LocalAcceptor acceptor{"1"};
-  auto promise = acceptor.prepare(getNewBallot(0)).semi().get();
+TEST_P(AcceptorTests, PrepareReturnsEmptyPromiseIfNotInitialized) {
+  auto paxosInstanceId = GetParam();
+  LocalAcceptor acceptor{"1", kvStore_};
+  auto promise =
+      acceptor.prepare(paxosInstanceId, getNewBallot(0)).semi().get();
 
   ASSERT_TRUE(std::holds_alternative<Promise>(promise));
 }
 
-TEST(AcceptorTests, PrepareReturnsFalseForSmallerOrEqualPromise) {
-  LocalAcceptor acceptor{"1"};
-  auto promise = acceptor.prepare(getNewBallot(10)).semi().get();
+TEST_P(AcceptorTests, PrepareReturnsFalseForSmallerOrEqualPromise) {
+  auto paxosInstanceId = GetParam();
+  LocalAcceptor acceptor{"1", kvStore_};
+  auto promise =
+      acceptor.prepare(paxosInstanceId, getNewBallot(10)).semi().get();
 
   ASSERT_TRUE(std::holds_alternative<Promise>(promise));
 
   for (int i = 0; i <= 10; i++) {
-    auto p = acceptor.prepare(getNewBallot(i)).semi().get();
+    auto p = acceptor.prepare(paxosInstanceId, getNewBallot(i)).semi().get();
     ASSERT_TRUE(std::holds_alternative<std::false_type>(p));
   }
 }
 
-TEST(AcceptorTests, PrepareReturnsAcceptedValue) {
-  LocalAcceptor acceptor{"1"};
+TEST_P(AcceptorTests, PrepareReturnsAcceptedValue) {
+  auto paxosInstanceId = GetParam();
+  LocalAcceptor acceptor{"1", kvStore_};
   auto ballotId = getNewBallot(10);
   std::string value{"hello_world"};
-  auto promise = acceptor.prepare(ballotId).semi().get();
+  auto promise = acceptor.prepare(paxosInstanceId, ballotId).semi().get();
   ASSERT_TRUE(std::holds_alternative<Promise>(promise));
 
   auto proposal = Proposal{};
   proposal.mutable_ballot_id()->CopyFrom(ballotId.id);
   proposal.set_value(value);
 
-  auto acceptedValue = acceptor.accept(std::move(proposal)).semi().get();
+  auto acceptedValue =
+      acceptor.accept(paxosInstanceId, std::move(proposal)).semi().get();
   ASSERT_TRUE(acceptedValue);
 
   for (auto id = ballotId.id.minor_id() + 1; id < 100; id++) {
-    auto prepareResult = acceptor.prepare(getNewBallot(id)).semi().get();
+    auto prepareResult =
+        acceptor.prepare(paxosInstanceId, getNewBallot(id)).semi().get();
     ASSERT_TRUE(std::holds_alternative<Promise>(prepareResult));
 
     auto p = std::get<Promise>(prepareResult);
@@ -56,24 +78,29 @@ TEST(AcceptorTests, PrepareReturnsAcceptedValue) {
   }
 }
 
-TEST(AcceptorTests, AfterAcceptingValueOldProposalAreDenied) {
-  LocalAcceptor acceptor{"1"};
+TEST_P(AcceptorTests, AfterAcceptingValueOldProposalAreDenied) {
+  auto paxosInstanceId = GetParam();
+  LocalAcceptor acceptor{"1", kvStore_};
   auto ballot{getNewBallot(10)};
   std::string value{"hello_world"};
-  auto promise = acceptor.prepare(ballot).semi().get();
+  auto promise = acceptor.prepare(paxosInstanceId, ballot).semi().get();
   ASSERT_TRUE(std::holds_alternative<Promise>(promise));
 
   auto proposal = Proposal{};
   proposal.mutable_ballot_id()->CopyFrom(ballot.id);
   proposal.set_value(value);
 
-  auto acceptedValue = acceptor.accept(proposal).semi().get();
+  auto acceptedValue = acceptor.accept(paxosInstanceId, proposal).semi().get();
   ASSERT_TRUE(acceptedValue);
 
   for (int id = 0; id <= ballot.id.minor_id(); id++) {
-    auto p = acceptor.prepare(getNewBallot(id)).semi().get();
+    auto p = acceptor.prepare(paxosInstanceId, getNewBallot(id)).semi().get();
     ASSERT_FALSE(std::get<std::false_type>(p));
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(AcceptorValueParameterizedTests, AcceptorTests,
+                         testing::Values("id1", "id2", "id3", "id4", "id5",
+                                         "id6", "id7", "id8"));
 
 } // namespace rk::projects::paxos


### PR DESCRIPTION
**Background**: The current version of paxos stores all the information in memory. 

**Implementation**: 
1. Use rocks db to store paxos instance information. 
2. Multiplex paxos acceptor based on paxosInstanceId.

