### PR TITLE
Add paxos based metadata store

### DIFF
--- a/log/impl/InMemoryMetadataStore.cc
+++ b/log/impl/InMemoryMetadataStore.cc
@@ -69,9 +69,9 @@ void InMemoryMetadataStore::printConfigChain() {
 }
 
 coro<void>
-InMemoryMetadataStore::compareAndAppendRange(VersionId versionId,
-                                             MetadataConfig newMetadataConfig) {
+InMemoryMetadataStore::compareAndAppendRange(MetadataConfig newMetadataConfig) {
   std::lock_guard<std::mutex> lockGuard{state_->mtx};
+  auto versionId = newMetadataConfig.previous_version_id();
 
   if (state_->configs_.empty()) {
     if (versionId != 0) {

--- a/log/impl/InMemoryMetadataStore.h
+++ b/log/impl/InMemoryMetadataStore.h
@@ -20,8 +20,7 @@ public:
 
   coro<VersionId> getCurrentVersionId() override;
 
-  coro<void> compareAndAppendRange(VersionId versionId,
-                                   MetadataConfig newMetadataConfig) override;
+  coro<void> compareAndAppendRange(MetadataConfig newMetadataConfig) override;
 
   void printConfigChain() override;
 

--- a/log/impl/PersistentMetadataStore.h
+++ b/log/impl/PersistentMetadataStore.h
@@ -43,9 +43,8 @@ public:
     return delegate_->getCurrentVersionId();
   }
 
-  coro<void> compareAndAppendRange(VersionId versionId,
-                                   MetadataConfig newMetadataConfig) override {
-    co_await stateMachine_->append(newMetadataConfig.SerializeAsString());
+  coro<void> compareAndAppendRange(MetadataConfig newMetadataConfig) override {
+    co_await stateMachine_->append(std::move(newMetadataConfig));
   }
 
   void printConfigChain() override { delegate_->printConfigChain(); }

--- a/log/impl/VirtualLogFactory.cc
+++ b/log/impl/VirtualLogFactory.cc
@@ -22,7 +22,7 @@ std::unique_ptr<VirtualLog> makeVirtualLog(std::string name) {
   config.set_start_index(1);
   config.set_end_index(1000);
 
-  metadataStore->compareAndAppendRange(0, config);
+  metadataStore->compareAndAppendRange(config).semi().get();
 
   std::vector<std::shared_ptr<Replica>> replicaSet;
   for (int i = 0; i < 5; i++) {

--- a/log/impl/VirtualLogImpl.cc
+++ b/log/impl/VirtualLogImpl.cc
@@ -215,7 +215,7 @@ VirtualLogImpl::reconfigure(MetadataConfig targetMetadataConfig) {
     replicaConfig->CopyFrom(targetMetadataConfig.replica_set_config());
 
     try {
-      co_await metadataStore_->compareAndAppendRange(versionId, newConfig);
+      co_await metadataStore_->compareAndAppendRange(newConfig);
       setState(newConfig.version_id());
       state_->sequencer->start(newConfig.version_id(), newConfig.start_index());
       co_return newConfig;

--- a/log/impl/tests/ReplicaTest.cc
+++ b/log/impl/tests/ReplicaTest.cc
@@ -50,7 +50,7 @@ protected:
       config.set_start_index(500);
       config.set_end_index(1000);
 
-      metadataStore->compareAndAppendRange(0, config).semi().get();
+      metadataStore->compareAndAppendRange(config).semi().get();
     }
 
     auto nanoLogFactory = std::make_shared<NanoLogFactory>(config_);

--- a/log/impl/tests/TestUtils.h
+++ b/log/impl/tests/TestUtils.h
@@ -93,7 +93,7 @@ createSequencer(std::int32_t numberOfBadReplicas = 0,
 
   config.mutable_sequencer_config()->set_id(sequencer->getId());
 
-  metadataStore->compareAndAppendRange(0, config).semi().get();
+  metadataStore->compareAndAppendRange(config).semi().get();
 
   return {sequencer,     replicaSet, badReplicaSet, goodReplicaSet,
           metadataStore, config,     registry};

--- a/log/include/MetadataStore.h
+++ b/log/include/MetadataStore.h
@@ -29,8 +29,7 @@ public:
   virtual coro<VersionId> getCurrentVersionId() = 0;
 
   virtual coro<void>
-  compareAndAppendRange(VersionId versionId,
-                        MetadataConfig newMetadataConfig) = 0;
+  compareAndAppendRange(MetadataConfig newMetadataConfig) = 0;
 
   virtual void printConfigChain() = 0;
 

--- a/log/server/MetadataServer.cc
+++ b/log/server/MetadataServer.cc
@@ -56,9 +56,7 @@ grpc::Status MetadataServer::compareAndAppendRange(
     const server::CompareAndAppendRangeRequest *request,
     ::google::protobuf::Empty *response) {
   try {
-    metadataStore_
-        ->compareAndAppendRange(request->metadata_version_id().id(),
-                                request->metadata_config())
+    metadataStore_->compareAndAppendRange(request->metadata_config())
         .semi()
         .get();
   } catch (const OptimisticConcurrencyException &e) {

--- a/statemachine/MetadataStoreStateMachine.h
+++ b/statemachine/MetadataStoreStateMachine.h
@@ -8,9 +8,10 @@
 
 namespace rk::projects::state_machine {
 
-class MetadataStoreStateMachine : public StateMachine<std::string, void> {
+class MetadataStoreStateMachine
+    : public StateMachine<durable_log::MetadataConfig, void> {
 private:
-  using applicator_t = Applicator<std::string, void>;
+  using applicator_t = Applicator<durable_log::MetadataConfig, void>;
   using appender_t = wor::WriteOnceRegisterChainAppender<std::string>;
 
 public:
@@ -21,8 +22,8 @@ public:
         chain_{std::move(chain)},
         appender_{std::make_shared<appender_t>(chain_)} {}
 
-  folly::coro::Task<void> append(std::string payload) override {
-    auto toWorId = co_await appender_->append(payload);
+  folly::coro::Task<void> append(durable_log::MetadataConfig config) override {
+    auto toWorId = co_await appender_->append(config.SerializeAsString());
     for (wor::WorId i = lastAppliedWorId_ + 1; i < toWorId; i++) {
       auto wor = chain_->get(i);
       // remove this in future as all the wors' should be completely written.
@@ -31,14 +32,25 @@ public:
       auto serializedPayload =
           std::get<std::string>(co_await wor.value()->read());
 
-      co_await applicator_->apply(serializedPayload);
+      auto metadataConfig = durable_log::MetadataConfig{};
+      bool parseResult = metadataConfig.ParseFromString(serializedPayload);
+      if (!parseResult) {
+        throw std::runtime_error{"non recoverable error"};
+      }
+
+      co_await applicator_->apply(metadataConfig);
+      lastAppliedWorId_ = i;
     }
 
-    co_return co_await applicator_->apply(payload);
+    co_await applicator_->apply(config);
+    lastAppliedWorId_ = toWorId;
+
+    co_return;
   }
 
   void setApplicator(
-      std::shared_ptr<Applicator<std::string, void>> applicator) override {
+      std::shared_ptr<Applicator<durable_log::MetadataConfig, void>> applicator)
+      override {
     applicator_ = std::move(applicator);
   }
 

--- a/statemachine/RocksStateMachine.h
+++ b/statemachine/RocksStateMachine.h
@@ -32,10 +32,10 @@ public:
           std::get<std::string>(co_await wor.value()->read());
       RocksTxn currentTxn{.serializedPayload = serializedPayload};
 
-      co_await applicator_->apply(currentTxn);
+      co_await applicator_->apply(std::move(currentTxn));
     }
 
-    co_return co_await applicator_->apply(txn);
+    co_return co_await applicator_->apply(std::move(txn));
   }
 
   void setApplicator(std::shared_ptr<applicator_t> applicator) override {

--- a/statemachine/RocksTxnApplicator.h
+++ b/statemachine/RocksTxnApplicator.h
@@ -17,7 +17,7 @@ public:
       std::shared_ptr<ConflictDetector> conflictDetector, rocksdb::DB *rocks)
       : conflictDetector_{std::move(conflictDetector)}, rocks_{rocks} {}
 
-  folly::coro::Task<RocksTxnResult> apply(RocksTxn &txn) override {
+  folly::coro::Task<RocksTxnResult> apply(RocksTxn txn) override {
     RocksTxnResult txnResult{.txnSucceeded = false,
                              .speculativeTxnResult =
                                  SpeculativeTxnResult{.conflictDetected = false,

--- a/statemachine/include/StateMachine.h
+++ b/statemachine/include/StateMachine.h
@@ -8,7 +8,7 @@ namespace rk::projects::state_machine {
 
 template <typename T, typename R> class Applicator {
 public:
-  virtual folly::coro::Task<R> apply(T &t) = 0;
+  virtual folly::coro::Task<R> apply(T t) = 0;
 };
 
 template <typename T, typename R> class StateMachine {

--- a/statemachine/tests/RocksStateMachineTests.cc
+++ b/statemachine/tests/RocksStateMachineTests.cc
@@ -44,8 +44,11 @@ TEST_F(RocksStateMachineTests, WriteSingleTxn) {
   using appender_t = wor::WriteOnceRegisterChainAppender<std::string>;
   auto conflictDetector = std::make_shared<ConflictDetector>();
   auto applicator = std::make_shared<RocksTxnApplicator>(conflictDetector, db_);
-  auto chain = std::make_shared<InMemoryWriteOnceRegisterChain>(
-      std::move(std::make_shared<InMemoryWriteOnceRegister>));
+  auto worFactory = [](WorId worId) {
+    return std::make_shared<InMemoryWriteOnceRegister>();
+  };
+
+  auto chain = std::make_shared<InMemoryWriteOnceRegisterChain>(worFactory);
   RocksStateMachine stm{applicator, chain};
   stm.setApplicator(applicator);
 

--- a/wor/WORFactory.cc
+++ b/wor/WORFactory.cc
@@ -3,12 +3,46 @@
 //
 
 #include "WORFactory.h"
+#include "persistence/RocksDbFactory.h"
+#include "persistence/RocksKVStoreLite.h"
+#include "wor/paxos/LocalAcceptor.h"
+#include "wor/paxos/PaxosWriteOnceRegister.h"
+#include "wor/paxos/ProposerImpl.h"
 
 namespace rk::projects::wor {
 
 std::unique_ptr<WriteOnceRegisterChain> makeChainUsingInMemoryWor() {
-  return std::make_unique<WriteOnceRegisterChainImpl>(
-      std::move(std::make_shared<InMemoryWriteOnceRegister>));
+  auto worFactory = [](WorId worId) {
+    return std::make_shared<InMemoryWriteOnceRegister>();
+  };
+  return std::make_unique<WriteOnceRegisterChainImpl>(std::move(worFactory));
+}
+
+std::unique_ptr<WriteOnceRegisterChain> makeChainUsingPaxosWor() {
+  int members{5};
+
+  std::vector<std::shared_ptr<paxos::Acceptor>> acceptors;
+  for (int i = 0; i < members; i++) {
+    std::string acceptorId = fmt::format("acceptor_{}", i);
+    persistence::RocksDbFactory::RocksDbConfig config{
+        .path = fmt::format(
+            "/tmp/paxos_tests/paxos_acceptor_tests{}_{}",
+            std::chrono::system_clock::now().time_since_epoch().count(), i),
+        .createIfMissing = true};
+    auto rocks = persistence::RocksDbFactory::provideSharedPtr(config);
+    auto kvStore =
+        std::make_shared<persistence::RocksKVStoreLite>(std::move(rocks));
+    acceptors.emplace_back(
+        std::make_shared<paxos::LocalAcceptor>(acceptorId, std::move(kvStore)));
+  }
+
+  auto proposer = std::make_shared<paxos::ProposerImpl>(members, acceptors);
+  auto worFactory = [proposer](WorId worId) mutable {
+    return std::make_shared<paxos::PaxosWriteOnceRegister>(worId,
+                                                           std::move(proposer));
+  };
+
+  return std::make_unique<WriteOnceRegisterChainImpl>(worFactory);
 }
 
 } // namespace rk::projects::wor

--- a/wor/WORFactory.h
+++ b/wor/WORFactory.h
@@ -9,5 +9,6 @@
 namespace rk::projects::wor {
 
 std::unique_ptr<WriteOnceRegisterChain> makeChainUsingInMemoryWor();
+std::unique_ptr<WriteOnceRegisterChain> makeChainUsingPaxosWor();
 
 } // namespace rk::projects::wor

--- a/wor/WriteOnceRegisterChainImpl.h
+++ b/wor/WriteOnceRegisterChainImpl.h
@@ -13,7 +13,7 @@ namespace rk::projects::wor {
 class WriteOnceRegisterChainImpl : public WriteOnceRegisterChain {
 public:
   explicit WriteOnceRegisterChainImpl(
-      std::function<std::shared_ptr<WriteOnceRegister>()> registerFactory)
+      std::function<std::shared_ptr<WriteOnceRegister>(WorId)> registerFactory)
       : worId_{0}, lookup_{}, mtx_{std::make_unique<std::mutex>()},
         registerFactory_{std::move(registerFactory)} {}
 
@@ -21,7 +21,7 @@ public:
     std::lock_guard lg{*mtx_};
 
     worId_++;
-    auto wor = registerFactory_();
+    auto wor = registerFactory_(worId_);
     lookup_.emplace(worId_, wor);
     return {worId_};
   }
@@ -60,7 +60,7 @@ private:
   WorId worId_;
   std::map<WorId, std::shared_ptr<WriteOnceRegister>> lookup_;
   std::unique_ptr<std::mutex> mtx_;
-  std::function<std::shared_ptr<WriteOnceRegister>()> registerFactory_;
+  std::function<std::shared_ptr<WriteOnceRegister>(WorId)> registerFactory_;
 };
 
 } // namespace rk::projects::wor

--- a/wor/inmemory/InMemoryWriteOnceRegister.h
+++ b/wor/inmemory/InMemoryWriteOnceRegister.h
@@ -1,6 +1,7 @@
 //
 // Created by Rahul  Kushwaha on 6/7/23.
 //
+#pragma once
 #include "wor/include/WriteOnceRegister.h"
 
 #include <memory>

--- a/wor/inmemory/InMemoryWriteOnceRegisterChain.h
+++ b/wor/inmemory/InMemoryWriteOnceRegisterChain.h
@@ -15,7 +15,7 @@ namespace rk::projects::wor {
 class InMemoryWriteOnceRegisterChain : public WriteOnceRegisterChainImpl {
 public:
   explicit InMemoryWriteOnceRegisterChain(
-      std::function<std::shared_ptr<WriteOnceRegister>()> registerFactory)
+      std::function<std::shared_ptr<WriteOnceRegister>(WorId)> registerFactory)
       : WriteOnceRegisterChainImpl(std::move(registerFactory)) {}
 };
 

--- a/wor/paxos/proto/PaxosMessage.proto
+++ b/wor/paxos/proto/PaxosMessage.proto
@@ -9,12 +9,12 @@ message BallotId{
 
 message Promise{
   BallotId ballot_id = 1;
-  optional string value = 2;
+  optional bytes value = 2;
 }
 
 message Proposal{
   BallotId ballot_id = 1;
-  string value = 2;
+  bytes value = 2;
 }
 
 message PaxosInstance{

--- a/wor/tests/WriteOnceRegisterChainAppenderTest.cc
+++ b/wor/tests/WriteOnceRegisterChainAppenderTest.cc
@@ -2,6 +2,7 @@
 // Created by Rahul  Kushwaha on 6/9/23.
 //
 #include "wor/WriteOnceRegisterChainAppender.h"
+#include "wor/WORFactory.h"
 #include "wor/inmemory/InMemoryWriteOnceRegisterChain.h"
 #include <fmt/format.h>
 #include <gtest/gtest.h>
@@ -11,8 +12,7 @@ namespace rk::projects::wor {
 
 TEST(WriteOnceRegisterChainAppenderTests, WriteToChain) {
   std::string value{"hello world"};
-  auto chain = std::make_shared<InMemoryWriteOnceRegisterChain>(
-      std::move(std::make_shared<InMemoryWriteOnceRegister>));
+  std::shared_ptr<WriteOnceRegisterChain> chain = makeChainUsingInMemoryWor();
   WriteOnceRegisterChainAppender<std::string> appender{chain};
   appender.append(value).semi().get();
   auto optionalWorId = chain->tail();
@@ -27,8 +27,7 @@ TEST(WriteOnceRegisterChainAppenderTests, WriteToChain) {
 
 TEST(WriteOnceRegisterChainAppenderTests, WriteMultipleToChain) {
   std::string valueFmt{"hello world {}"};
-  auto chain = std::make_shared<InMemoryWriteOnceRegisterChain>(
-      std::move(std::make_shared<InMemoryWriteOnceRegister>));
+  std::shared_ptr<WriteOnceRegisterChain> chain = makeChainUsingInMemoryWor();
   WriteOnceRegisterChainAppender<std::string> appender{chain};
 
   std::vector<std::string> values;


### PR DESCRIPTION
**Background**: Add new parameter to MetadataStore parameterized tests. Paxos based WOR. 

**Implementation**:
1. Fix the MetadataStore API. PreviousVersionId is always part of the MetadataConfig object. There is no need to have it as a parameter to the compareAndAppend method. 
2. Add paxos based parameterized tests for MetadataStore.