### PR TITLE
Add reconfiguration to paxos state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(cmake/gtest.cmake)
 include(cmake/prometheus.cmake)
 include(cmake/openssl.cmake)
 include(cmake/backward.cmake)
+include(cmake/fmt.cmake)
 
 set(ENV{OPENSSL_ROOT_DIR} ${OPENSSL_INSTALL_DIR})
 find_package(OpenSSL 1.1.1 MODULE)

--- a/applications/counter/CounterApp.h
+++ b/applications/counter/CounterApp.h
@@ -6,11 +6,17 @@
 #include <memory>
 #include <unordered_map>
 
+#include "applications/counter/CounterAppStateMachine.h"
 #include "applications/counter/proto/CounterEntry.pb.h"
 #include "folly/experimental/coro/Task.h"
-#include "log/include/VirtualLog.h"
 
 namespace rk::projects::counter_app {
+template <typename T> using coro = folly::coro::Task<T>;
+
+struct CounterKeyValue {
+  std::string key;
+  std::int64_t val;
+};
 
 using namespace rk::projects::durable_log;
 
@@ -20,47 +26,33 @@ public:
     std::string key;
     std::int64_t incrBy;
   };
-
   struct DecrOperation {
     std::string key;
     std::int64_t decrBy;
   };
 
-  struct CounterValue {
-    std::string key;
-    std::int64_t val;
-  };
-  using CounterValues = std::vector<CounterValue>;
-
   using Operation = std::variant<IncrOperation, DecrOperation>;
 
-  explicit CounterApp(std::shared_ptr<VirtualLog> virtualLog);
+  explicit CounterApp(std::shared_ptr<CounterAppStateMachine> stateMachine);
 
-  folly::coro::Task<std::int64_t> incrementAndGet(std::string key,
-                                                  std::int64_t incrBy);
-  folly::coro::Task<std::int64_t> decrementAndGet(std::string key,
-                                                  std::int64_t decrBy);
-  folly::coro::Task<std::int64_t> getValue(std::string key);
-  folly::coro::Task<std::vector<CounterApp::CounterValue>>
-  batchUptate(std::vector<Operation> operations);
+  coro<std::int64_t> incrementAndGet(std::string key, std::int64_t incrBy);
+  coro<std::int64_t> decrementAndGet(std::string key, std::int64_t decrBy);
+  coro<std::int64_t> getValue(std::string key);
+  coro<std::vector<CounterKeyValue>>
+  batchUpdate(std::vector<Operation> operations);
 
-private:
-  static std::string serialize(std::string key, std::int64_t val,
-                               CounterLogEntry_CommandType commandType);
-  static CounterLogEnteries deserialize(const std::string &payload);
-
-  static std::string serialize(const std::vector<Operation> &operations);
-
-  std::vector<CounterValue> apply(const CounterLogEnteries &counterLogEnteries);
-  std::vector<CounterValue> sync(LogId to);
+  std::vector<CounterKeyValue>
+  apply(const CounterLogEnteries &counterLogEntries);
 
 private:
-  std::shared_ptr<VirtualLog> virtualLog_;
+  static CounterLogEnteries serialize(const std::vector<Operation> &operations);
+
+private:
+  std::shared_ptr<CounterAppStateMachine> stateMachine_;
   LogId lastAppliedEntry_;
   std::unique_ptr<std::mutex> mtx_;
 
   std::unordered_map<std::string, std::atomic_int64_t> lookup_;
-  std::vector<CounterValue> applyLogEntries(LogId logIdToApply);
 };
 
 } // namespace rk::projects::counter_app

--- a/applications/counter/CounterAppEnsembleNode.h
+++ b/applications/counter/CounterAppEnsembleNode.h
@@ -87,7 +87,7 @@ CounterAppEnsemble makeCounterAppEnsemble(std::string appName,
   metadataConfig.set_start_index(1);
   metadataConfig.set_end_index(1000);
 
-  metadataStore->compareAndAppendRange(0, metadataConfig);
+  metadataStore->compareAndAppendRange(metadataConfig).semi().get();
 
   std::shared_ptr<Registry> registry = makeRegistry();
 

--- a/applications/counter/CounterAppStateMachine.cc
+++ b/applications/counter/CounterAppStateMachine.cc
@@ -1,0 +1,52 @@
+//
+// Created by Rahul  Kushwaha on 7/15/23.
+//
+#include "applications/counter/CounterAppStateMachine.h"
+#include "applications/counter/CounterApp.h"
+
+namespace rk::projects::counter_app {
+
+CounterAppStateMachine::CounterAppStateMachine(
+    std::shared_ptr<durable_log::VirtualLog> virtualLog)
+    : lastAppliedLogId_{0}, virtualLog_{std::move(virtualLog)},
+      applicator_{nullptr} {}
+
+folly::coro::Task<std::vector<CounterKeyValue>>
+CounterAppStateMachine::append(CounterLogEnteries t) {
+  auto logId = co_await virtualLog_->append(t.SerializeAsString());
+  while (lastAppliedLogId_ <= logId) {
+    auto nextLog = co_await virtualLog_->getLogEntry(logId);
+    if (std::holds_alternative<durable_log::LogReadError>(nextLog)) {
+      auto logReadError = std::get<durable_log::LogReadError>(nextLog);
+      throw std::runtime_error{"log read error"};
+    }
+
+    auto logEntry = std::get<durable_log::LogEntry>(nextLog);
+    CounterLogEnteries entries{};
+    auto parseResult = entries.ParseFromString(logEntry.payload);
+    if (!parseResult) {
+      throw std::runtime_error{"protobuf parse result"};
+    }
+
+    auto applyResult = co_await applicator_->apply(entries);
+    lastAppliedLogId_ = logEntry.logId;
+    if (lastAppliedLogId_ == logId) {
+      co_return applyResult;
+    }
+  }
+
+  co_return co_await folly::coro::makeErrorTask<std::vector<CounterKeyValue>>(
+      folly::exception_wrapper{std::runtime_error{
+          "reached end of loop. should not happen. un-recoverable error."}});
+}
+
+void CounterAppStateMachine::setApplicator(
+    std::shared_ptr<applicator_t> applicator) {
+  applicator_ = std::move(applicator);
+}
+
+folly::coro::Task<void> CounterAppStateMachine::sync() {
+  co_await virtualLog_->sync();
+}
+
+} // namespace rk::projects::counter_app

--- a/applications/counter/CounterAppStateMachine.h
+++ b/applications/counter/CounterAppStateMachine.h
@@ -1,0 +1,37 @@
+//
+// Created by Rahul  Kushwaha on 7/15/23.
+//
+#pragma once
+#include "applications/counter/CounterApplicator.h"
+#include "applications/counter/proto/CounterEntry.pb.h"
+#include "applications/counter/server/proto/CounterService.pb.h"
+#include "log/include/VirtualLog.h"
+#include "statemachine/include/StateMachine.h"
+
+namespace rk::projects::counter_app {
+
+class CounterApp;
+class CounterKeyValue;
+
+class CounterAppStateMachine
+    : public state_machine::StateMachine<CounterLogEnteries,
+                                         std::vector<CounterKeyValue>> {
+  using applicator_t = state_machine::Applicator<CounterLogEnteries,
+                                                 std::vector<CounterKeyValue>>;
+
+public:
+  explicit CounterAppStateMachine(
+      std::shared_ptr<durable_log::VirtualLog> virtualLog);
+
+  folly::coro::Task<std::vector<CounterKeyValue>>
+  append(CounterLogEnteries t) override;
+  void setApplicator(std::shared_ptr<applicator_t> applicator) override;
+  folly::coro::Task<void> sync() override;
+
+private:
+  durable_log::LogId lastAppliedLogId_;
+  std::shared_ptr<durable_log::VirtualLog> virtualLog_;
+  std::shared_ptr<applicator_t> applicator_;
+};
+
+} // namespace rk::projects::counter_app

--- a/applications/counter/CounterApplicator.cc
+++ b/applications/counter/CounterApplicator.cc
@@ -1,0 +1,17 @@
+//
+// Created by Rahul  Kushwaha on 7/15/23.
+//
+#include "applications/counter/CounterApplicator.h"
+#include "applications/counter/CounterApp.h"
+
+namespace rk::projects::counter_app {
+
+CounterApplicator::CounterApplicator(std::shared_ptr<CounterApp> app)
+    : app_{std::move(app)} {}
+
+folly::coro::Task<applicatorOutput_t>
+CounterApplicator::apply(applicatorInput_t t) {
+  co_return app_->apply(t);
+}
+
+} // namespace rk::projects::counter_app

--- a/applications/counter/CounterApplicator.h
+++ b/applications/counter/CounterApplicator.h
@@ -1,0 +1,29 @@
+//
+// Created by Rahul  Kushwaha on 7/15/23.
+//
+
+#pragma once
+#include "applications/counter/proto/CounterEntry.pb.h"
+#include "folly/experimental/coro/Task.h"
+#include "statemachine/include/StateMachine.h"
+
+namespace rk::projects::counter_app {
+
+class CounterApp;
+class CounterKeyValue;
+
+using applicatorInput_t = CounterLogEnteries;
+using applicatorOutput_t = std::vector<CounterKeyValue>;
+
+class CounterApplicator
+    : public state_machine::Applicator<applicatorInput_t, applicatorOutput_t> {
+
+public:
+  explicit CounterApplicator(std::shared_ptr<CounterApp> app);
+
+  folly::coro::Task<applicatorOutput_t> apply(applicatorInput_t t) override;
+
+private:
+  std::shared_ptr<CounterApp> app_;
+};
+} // namespace rk::projects::counter_app

--- a/applications/counter/server/CounterAppServer.h
+++ b/applications/counter/server/CounterAppServer.h
@@ -15,7 +15,7 @@ public:
 
   grpc::Status IncrementAndGet(::grpc::ServerContext *context,
                                const IncrementRequest *request,
-                               CounterValue *response) override {
+                               CounterKeyValue *response) override {
     LOG(INFO) << "Server Request: IncrementAndGet";
 
     response->set_value(
@@ -27,7 +27,7 @@ public:
 
   grpc::Status DecrementAndGet(::grpc::ServerContext *context,
                                const DecrementRequest *request,
-                               CounterValue *response) override {
+                               CounterKeyValue *response) override {
     LOG(INFO) << "Server Request: DecrementAndGet";
 
     response->set_value(
@@ -39,7 +39,7 @@ public:
 
   grpc::Status GetCounterValue(::grpc::ServerContext *context,
                                const GetCounterValueRequest *request,
-                               CounterValue *response) override {
+                               CounterKeyValue *response) override {
     LOG(INFO) << "Server Request: GetCounterValue";
 
     response->set_value(counterApp_->getValue(request->key()).semi().get());

--- a/cmake/fmt.cmake
+++ b/cmake/fmt.cmake
@@ -1,0 +1,6 @@
+FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+        GIT_TAG 10.0.0
+)
+FetchContent_MakeAvailable(fmt)

--- a/cmake/source_list.cmake
+++ b/cmake/source_list.cmake
@@ -8,6 +8,10 @@ set(
         applications/counter/CounterApp.h
         applications/counter/CounterHealthCheck.cc
         applications/counter/CounterHealthCheck.h
+        applications/counter/CounterAppStateMachine.cc
+        applications/counter/CounterAppStateMachine.h
+        applications/counter/CounterApplicator.cc
+        applications/counter/CounterApplicator.h
         applications/counter/client/CounterAppClient.cc
         applications/counter/client/CounterAppClient.h
         applications/counter/server/CounterAppServer.h

--- a/log/client/MetadataStoreClient.cc
+++ b/log/client/MetadataStoreClient.cc
@@ -66,12 +66,10 @@ folly::SemiFuture<VersionId> MetadataStoreClient::getCurrentVersionId() {
 }
 
 folly::SemiFuture<folly::Unit>
-MetadataStoreClient::compareAndAppendRange(VersionId versionId,
-                                           MetadataConfig newMetadataConfig) {
+MetadataStoreClient::compareAndAppendRange(MetadataConfig newMetadataConfig) {
   grpc::ClientContext context;
   context.set_deadline(std::chrono::system_clock::now() + CLIENT_TIMEOUT);
   server::CompareAndAppendRangeRequest request;
-  request.mutable_metadata_version_id()->set_id(versionId);
   request.mutable_metadata_config()->Swap(&newMetadataConfig);
   google::protobuf::Empty response;
 

--- a/log/client/MetadataStoreClient.h
+++ b/log/client/MetadataStoreClient.h
@@ -18,7 +18,7 @@ public:
   folly::SemiFuture<MetadataConfig> getConfigUsingLogId(LogId logId);
   folly::SemiFuture<VersionId> getCurrentVersionId();
   folly::SemiFuture<folly::Unit>
-  compareAndAppendRange(VersionId versionId, MetadataConfig newMetadataConfig);
+  compareAndAppendRange(MetadataConfig newMetadataConfig);
   folly::coro::Task<void> printConfigChain();
 
 private:

--- a/log/impl/RemoteMetadataStore.h
+++ b/log/impl/RemoteMetadataStore.h
@@ -28,9 +28,8 @@ public:
     co_return client_->getCurrentVersionId().get();
   }
 
-  coro<void> compareAndAppendRange(VersionId versionId,
-                                   MetadataConfig newMetadataConfig) override {
-    co_await client_->compareAndAppendRange(versionId, newMetadataConfig);
+  coro<void> compareAndAppendRange(MetadataConfig newMetadataConfig) override {
+    co_await client_->compareAndAppendRange(newMetadataConfig);
   }
 
   void printConfigChain() override { client_->printConfigChain().semi().get(); }

--- a/log/impl/VirtualLogImpl.cc
+++ b/log/impl/VirtualLogImpl.cc
@@ -216,7 +216,7 @@ VirtualLogImpl::reconfigure(MetadataConfig targetMetadataConfig) {
 
     try {
       co_await metadataStore_->compareAndAppendRange(newConfig);
-      setState(newConfig.version_id());
+      co_await setState(newConfig.version_id());
       state_->sequencer->start(newConfig.version_id(), newConfig.start_index());
       co_return newConfig;
     } catch (const OptimisticConcurrencyException &e) {

--- a/log/impl/tests/MetadataStoreTest.cc
+++ b/log/impl/tests/MetadataStoreTest.cc
@@ -33,14 +33,14 @@ protected:
       auto chain = wor::makeChainUsingInMemoryWor();
       auto inMemoryMetadataStore = std::make_shared<InMemoryMetadataStore>();
       return std::make_unique<PersistentMetadataStore>(
-          std::move(inMemoryMetadataStore), std::move(chain));
+          std::move(inMemoryMetadataStore));
     }
 
     case MetadataStoreType::PaxosWor: {
       auto chain = wor::makeChainUsingPaxosWor();
       auto inMemoryMetadataStore = std::make_shared<InMemoryMetadataStore>();
       return std::make_unique<PersistentMetadataStore>(
-          std::move(inMemoryMetadataStore), std::move(chain));
+          std::move(inMemoryMetadataStore));
     }
     default:
       throw std::runtime_error{"unknown metadata store type"};

--- a/log/server/proto/MetadataService.proto
+++ b/log/server/proto/MetadataService.proto
@@ -18,8 +18,7 @@ service MetadataService{
 }
 
 message CompareAndAppendRangeRequest{
-  MetadataVersionId metadata_version_id = 1;
-  MetadataConfig metadata_config = 2;
+  MetadataConfig metadata_config = 1;
 }
 
 message LogId{

--- a/statemachine/MetadataStoreStateMachine.h
+++ b/statemachine/MetadataStoreStateMachine.h
@@ -4,65 +4,99 @@
 #pragma once
 #include "statemachine/Common.h"
 #include "statemachine/include/StateMachine.h"
+#include "wor/WORFactory.h"
 #include "wor/WriteOnceRegisterChainAppender.h"
+#include "wor/include/WriteOnceRegister.h"
 
 namespace rk::projects::state_machine {
 
 class MetadataStoreStateMachine
-    : public StateMachine<durable_log::MetadataConfig, void> {
-private:
-  using applicator_t = Applicator<durable_log::MetadataConfig, void>;
-  using appender_t = wor::WriteOnceRegisterChainAppender<std::string>;
+    : public StateMachine<durable_log::MetadataConfig, ApplicationResult> {
+  using applicator_t =
+      Applicator<durable_log::MetadataConfig, ApplicationResult>;
+  using currentConfigSupplier_t =
+      std::function<folly::SemiFuture<durable_log::MetadataConfig>()>;
 
 public:
   explicit MetadataStoreStateMachine(
       std::shared_ptr<applicator_t> applicator,
-      std::shared_ptr<wor::WriteOnceRegisterChain> chain)
-      : lastAppliedWorId_{0}, applicator_{std::move(applicator)},
-        chain_{std::move(chain)},
-        appender_{std::make_shared<appender_t>(chain_)} {}
+      durable_log::MetadataConfig bootstrapConfig,
+      currentConfigSupplier_t currentConfigSupplier)
+      : applicator_{std::move(applicator)},
+        currentConfig_{std::move(bootstrapConfig)},
+        lastAppliedWorId_{currentConfig_.start_index()},
+        currentConfigSupplier_{std::move(currentConfigSupplier)} {}
 
-  folly::coro::Task<void> append(durable_log::MetadataConfig config) override {
-    auto toWorId = co_await appender_->append(config.SerializeAsString());
-    for (wor::WorId i = lastAppliedWorId_ + 1; i < toWorId; i++) {
-      auto wor = chain_->get(i);
-      // remove this in future as all the wors' should be completely written.
-      assert(wor.has_value());
-      auto worValue = co_await wor.value()->read();
+  folly::coro::Task<ApplicationResult>
+  append(durable_log::MetadataConfig config) override {
+    auto payload = config.SerializeAsString();
 
-      if (std::holds_alternative<wor::WriteOnceRegister::ReadError>(worValue)) {
-        throw std::runtime_error{wor::WriteOnceRegister::toString(
-            std::get<wor::WriteOnceRegister::ReadError>(worValue))};
+    bool successfullyWritten{false};
+    ApplicationResult result;
+
+    while (!successfullyWritten) {
+      auto nextWorId = lastAppliedWorId_ + 1;
+
+      auto wor = wor::makePaxosWor(nextWorId, currentConfig_);
+      bool worIterationComplete{false};
+      while (!worIterationComplete) {
+        auto lockId = co_await wor->lock();
+        if (!lockId.has_value()) {
+          continue;
+        }
+
+        auto writeResponse = co_await wor->write(lockId.value(), payload);
+        if (writeResponse) {
+          successfullyWritten = true;
+          break;
+        }
+
+        auto readValue = co_await wor->read();
+        if (std::holds_alternative<wor::WriteOnceRegister::ReadError>(
+                readValue)) {
+          LOG(INFO) << "failed to read wor: "
+                    << wor::WriteOnceRegister::toString(
+                           std::get<wor::WriteOnceRegister::ReadError>(
+                               readValue));
+          // We either encounter an error or it is not written. In any case
+          // we need to continue writing to it until it succeeds.
+          continue;
+        }
+
+        auto worValue = std::get<std::string>(readValue);
+        auto metadataConfig = durable_log::MetadataConfig{};
+        bool parseResult = metadataConfig.ParseFromString(worValue);
+        if (!parseResult) {
+          co_return folly::exception_wrapper{
+              std::runtime_error{"protobuf parse error"}};
+        }
+
+        result = co_await applicator_->apply(metadataConfig);
+        currentConfig_ = co_await currentConfigSupplier_();
+        lastAppliedWorId_ = nextWorId;
+
+        if (worValue == payload) {
+          successfullyWritten = true;
+        }
+
+        worIterationComplete = true;
       }
-
-      auto serializedPayload = std::get<std::string>(worValue);
-      auto metadataConfig = durable_log::MetadataConfig{};
-      bool parseResult = metadataConfig.ParseFromString(serializedPayload);
-      if (!parseResult) {
-        throw std::runtime_error{"non recoverable error"};
-      }
-
-      co_await applicator_->apply(metadataConfig);
-      lastAppliedWorId_ = i;
     }
 
-    co_await applicator_->apply(config);
-    lastAppliedWorId_ = toWorId;
-
-    co_return;
+    co_return result;
   }
 
-  void setApplicator(
-      std::shared_ptr<Applicator<durable_log::MetadataConfig, void>> applicator)
-      override {
+  void setApplicator(std::shared_ptr<
+                     Applicator<durable_log::MetadataConfig, ApplicationResult>>
+                         applicator) override {
     applicator_ = std::move(applicator);
   }
 
 private:
+  durable_log::MetadataConfig currentConfig_;
   wor::WorId lastAppliedWorId_;
   std::shared_ptr<applicator_t> applicator_;
-  std::shared_ptr<wor::WriteOnceRegisterChain> chain_;
-  std::shared_ptr<appender_t> appender_;
+  currentConfigSupplier_t currentConfigSupplier_;
 };
 
 } // namespace rk::projects::state_machine

--- a/statemachine/include/StateMachine.h
+++ b/statemachine/include/StateMachine.h
@@ -6,14 +6,17 @@
 
 namespace rk::projects::state_machine {
 
+template <typename T> using coro = folly::coro::Task<T>;
+
 template <typename T, typename R> class Applicator {
 public:
-  virtual folly::coro::Task<R> apply(T t) = 0;
+  virtual coro<R> apply(T t) = 0;
 };
 
 template <typename T, typename R> class StateMachine {
 public:
-  virtual folly::coro::Task<R> append(T t) = 0;
+  virtual coro<R> append(T t) = 0;
+  virtual coro<void> sync() { co_return; }
   virtual void setApplicator(std::shared_ptr<Applicator<T, R>> applicator) = 0;
 };
 

--- a/wor/WORFactory.h
+++ b/wor/WORFactory.h
@@ -3,11 +3,14 @@
 //
 #pragma once
 
+#include "log/proto/MetadataConfig.pb.h"
 #include "wor/WriteOnceRegisterChainImpl.h"
 #include "wor/inmemory/InMemoryWriteOnceRegister.h"
 
 namespace rk::projects::wor {
 
+std::unique_ptr<WriteOnceRegister>
+makePaxosWor(WorId worId, const durable_log::MetadataConfig &metadataConfig);
 std::unique_ptr<WriteOnceRegisterChain> makeChainUsingInMemoryWor();
 std::unique_ptr<WriteOnceRegisterChain> makeChainUsingPaxosWor();
 


### PR DESCRIPTION
**Background**: The current implementation of metadata reconfiguration does not update the configuration for the next round of paxos. 

**Implementation**: 
1. Instead of using a WOR chain, directly use a WOR in paxos metadata store. 
2. Use statemachine in counter app. 

**Tests**: 
1. Update tests to use statemachine for counter app.