### PR TITLE
Add NullStateMachine for default parameter

### DIFF
--- a/applications/counter/CounterAppStateMachine.cc
+++ b/applications/counter/CounterAppStateMachine.cc
@@ -49,6 +49,14 @@ void CounterAppStateMachine::setApplicator(
   applicator_ = std::move(applicator);
 }
 
+void CounterAppStateMachine::setUpstreamStateMachine(
+    std::shared_ptr<
+        state_machine::StateMachine<durable_log::LogEntry_1, ReturnType>>
+        upstreamStateMachine_) {
+  throw std::runtime_error{
+      "counterapp state machine does not require upstream state machine"};
+}
+
 folly::coro::Task<void> CounterAppStateMachine::sync() {
   co_await downstreamStateMachine_->sync();
 }

--- a/applications/counter/CounterAppStateMachine.h
+++ b/applications/counter/CounterAppStateMachine.h
@@ -39,6 +39,11 @@ public:
   void setApplicator(std::shared_ptr<applicator_t> applicator) override;
   folly::coro::Task<void> sync() override;
 
+  void setUpstreamStateMachine(
+      std::shared_ptr<
+          state_machine::StateMachine<durable_log::LogEntry_1, ReturnType>>
+          upstreamStateMachine_) override;
+
 private:
   durable_log::LogId lastAppliedLogId_;
   std::shared_ptr<

--- a/applications/mydb/backend/KeySerializer.cc
+++ b/applications/mydb/backend/KeySerializer.cc
@@ -208,7 +208,7 @@ maximumSecondaryIndexKey(const internal::Table &table,
       ss << secondaryIndexKey(table, indexId, secondaryKeyValues,
                               primaryKeyValues)
          << DEFAULT_ESCAPE_CHARACTER << "ZZZZZZ";
-      LOG(INFO)<<ss.str();
+      LOG(INFO) << ss.str();
       return ss.str();
     }
   }

--- a/applications/mydb/backend/KeySerializer.h
+++ b/applications/mydb/backend/KeySerializer.h
@@ -46,7 +46,6 @@ std::string maximumIndexKey(const internal::Table &table,
                             TableSchemaType::TableIdType indexId,
                             std::vector<ColumnValue> values);
 
-
 std::string
 maximumSecondaryIndexKey(const internal::Table &table,
                          TableSchemaType::TableIdType indexId,

--- a/applications/mydb/backend/QueryExecutor.cc
+++ b/applications/mydb/backend/QueryExecutor.cc
@@ -92,10 +92,10 @@ InternalTable QueryExecutor::tableScan(InternalTable internalTable,
       // total number of values present in the startKey should be equal to
       // the number of columns in primary prefix.
       assert(indexQueryOptions.primaryKeyValues.size() ==
-              internalTable.schema->rawTable()
-                  .primary_key_index()
-                  .column_ids()
-                  .size());
+             internalTable.schema->rawTable()
+                 .primary_key_index()
+                 .column_ids()
+                 .size());
 
       return prefix::maximumSecondaryIndexKey(
           internalTable.schema->rawTable(), indexQueryOptions.indexId,

--- a/applications/mydb/backend/tests/TestUtils.cc
+++ b/applications/mydb/backend/tests/TestUtils.cc
@@ -190,33 +190,31 @@ std::vector<ColumnValue> parsePrimaryKeyValues(InternalTable internalTable) {
   return {};
 }
 
-
-std::vector<ColumnValue> parseSecondaryKeyValues(InternalTable internalTable, int secondarykeyIndex) {
+std::vector<ColumnValue> parseSecondaryKeyValues(InternalTable internalTable,
+                                                 int secondarykeyIndex) {
   auto &arrowTable = *internalTable.table;
   auto &rawTable = internalTable.schema->rawTable();
 
-  for (std::int32_t rowIdx = 0; rowIdx < arrowTable.num_rows();
-       rowIdx++) {
+  for (std::int32_t rowIdx = 0; rowIdx < arrowTable.num_rows(); rowIdx++) {
     auto totalChunks = arrowTable.columns().front()->num_chunks();
     for (int chunkIdx = 0; chunkIdx < totalChunks; chunkIdx++) {
       std::vector<ColumnValue> secondaryIdxValues;
       LOG(INFO) << "ToTAL COlS: "
                 << rawTable.primary_key_index().column_ids().size();
 
-      for (auto colId: rawTable.secondary_index(0).column_ids()) {
+      for (auto colId : rawTable.secondary_index(0).column_ids()) {
         auto col = internalTable.schema->getColumn(colId);
-        auto arrowCol =
-            arrowTable.GetColumnByName(col.name())->chunk(chunkIdx);
+        auto arrowCol = arrowTable.GetColumnByName(col.name())->chunk(chunkIdx);
         ColumnValue columnValue;
 
-        if (col.column_type()
-            == mydb::Column_COLUMN_TYPE::Column_COLUMN_TYPE_INT64) {
+        if (col.column_type() ==
+            mydb::Column_COLUMN_TYPE::Column_COLUMN_TYPE_INT64) {
           auto chunk = std::static_pointer_cast<arrow::Int64Array>(arrowCol);
           auto val = chunk->Value(rowIdx);
           LOG(INFO) << val;
           columnValue = {val};
-        } else if (col.column_type()
-                   == mydb::Column_COLUMN_TYPE::Column_COLUMN_TYPE_STRING) {
+        } else if (col.column_type() ==
+                   mydb::Column_COLUMN_TYPE::Column_COLUMN_TYPE_STRING) {
           auto chunk = std::static_pointer_cast<arrow::StringArray>(arrowCol);
           auto val = chunk->Value(rowIdx);
           LOG(INFO) << val;
@@ -232,6 +230,5 @@ std::vector<ColumnValue> parseSecondaryKeyValues(InternalTable internalTable, in
 
   return {};
 }
-
 
 } // namespace rk::projects::mydb::test_utils

--- a/applications/mydb/backend/tests/TestUtils.h
+++ b/applications/mydb/backend/tests/TestUtils.h
@@ -6,7 +6,7 @@
 #include "folly/Conv.h"
 #include <arrow/array.h>
 #include <arrow/builder.h>
-//#include <arrow/compute/exec/exec_plan.h>
+// #include <arrow/compute/exec/exec_plan.h>
 #include <arrow/dataset/dataset.h>
 #include <arrow/table.h>
 #include <cstdint>
@@ -36,6 +36,7 @@ InternalTable getInternalTable(std::int32_t numRows = 10, int numIntColumns = 5,
 
 std::vector<ColumnValue> parsePrimaryKeyValues(InternalTable internalTable);
 
-std::vector<ColumnValue> parseSecondaryKeyValues(InternalTable internalTable, int secondaryKeyIndex);
+std::vector<ColumnValue> parseSecondaryKeyValues(InternalTable internalTable,
+                                                 int secondaryKeyIndex);
 
 } // namespace rk::projects::mydb::test_utils

--- a/cmake/source_list.cmake
+++ b/cmake/source_list.cmake
@@ -103,6 +103,7 @@ set(
         wor/paxos/RemoteAcceptor.h
 
         statemachine/include/StateMachine.h
+        statemachine/NullStateMachine.h
         statemachine/RocksStateMachine.h
         statemachine/ConflictDetector.h
         statemachine/RocksTxnApplicator.h

--- a/log/include/Common.h
+++ b/log/include/Common.h
@@ -62,9 +62,7 @@ public:
 
 class NotImplementedException : public std::exception {
 public:
-  const char *what() const noexcept override {
-    return "Method Not Implmented";
-  }
+  const char *what() const noexcept override { return "Method Not Implmented"; }
 };
 
 class MetadataBlockNotFound : public std::exception {

--- a/statemachine/LogTrimStateMachine.h
+++ b/statemachine/LogTrimStateMachine.h
@@ -3,6 +3,7 @@
 //
 #pragma once
 #include "log/proto/LogEntry.pb.h"
+#include "statemachine/NullStateMachine.h"
 #include "statemachine/include/StateMachine.h"
 
 namespace rk::projects::state_machine {
@@ -17,7 +18,8 @@ public:
       std::shared_ptr<StateMachine<LogEntry_1, R>> downstreamStateMachine)
       : applicator_{std::move(applicator)},
         downstreamStateMachine_{std::move(downstreamStateMachine)},
-        upstreamStateMachine_{nullptr} {}
+        upstreamStateMachine_{
+            std::make_shared<NullStateMachine<LogEntry_1, R>>()} {}
 
   coro<R> append(rk::projects::durable_log::LogEntry_1 t) override {
     co_return co_await downstreamStateMachine_->append(std::move(t));

--- a/statemachine/MetadataStoreStateMachine.h
+++ b/statemachine/MetadataStoreStateMachine.h
@@ -141,6 +141,14 @@ public:
     applicator_ = std::move(applicator);
   }
 
+  void setUpstreamStateMachine(
+      std::shared_ptr<
+          StateMachine<durable_log::MetadataConfig, ApplicationResult>>
+          upstreamStateMachine) override {
+    throw std::runtime_error{
+        "metadata state machine does not require upstream state machine"};
+  }
+
 private:
   // TODO(rahul): Refactor out lock. Handle somewhere else.
   std::unique_ptr<std::mutex> mtx_;

--- a/statemachine/NullStateMachine.h
+++ b/statemachine/NullStateMachine.h
@@ -1,0 +1,43 @@
+//
+// Created by Rahul  Kushwaha on 9/5/23.
+//
+#pragma once
+
+#include "log/proto/LogEntry.pb.h"
+#include "statemachine/include/StateMachine.h"
+
+namespace rk::projects::state_machine {
+using namespace rk::projects::durable_log;
+
+class NullStateMachineError : std::runtime_error {
+public:
+  explicit NullStateMachineError(const std::string &errorMessage)
+      : std::runtime_error(errorMessage) {}
+};
+
+template <typename T, typename R>
+class NullStateMachine : public StateMachine<T, R> {
+
+  coro<R> append(T t) {
+    throw NullStateMachineError{"NullStateMachine does not work"};
+  }
+
+  coro<R> apply(T t) {
+    throw NullStateMachineError{"NullStateMachine does not work"};
+  }
+
+  coro<void> sync() {
+    throw NullStateMachineError{"NullStateMachine does not work"};
+  }
+
+  void setApplicator(std::shared_ptr<Applicator<T, R>> applicator) {
+    throw NullStateMachineError{"NullStateMachine does not work"};
+  }
+
+  virtual void setUpstreamStateMachine(
+      std::shared_ptr<StateMachine<T, R>> upstreamStateMachine) {
+    throw NullStateMachineError{"NullStateMachine does not work"};
+  }
+};
+
+} // namespace rk::projects::state_machine

--- a/statemachine/RocksStateMachine.h
+++ b/statemachine/RocksStateMachine.h
@@ -46,6 +46,13 @@ public:
     applicator_ = std::move(applicator);
   }
 
+  void setUpstreamStateMachine(
+      std::shared_ptr<StateMachine<RocksTxn, RocksTxnResult>>
+          upstreamStateMachine) override {
+    throw std::runtime_error{"rocksStateMachine state machine does not require "
+                             "upstream state machine"};
+  }
+
 private:
   wor::WorId lastAppliedWorId_;
   std::shared_ptr<applicator_t> applicator_;

--- a/statemachine/VirtualLogStateMachine.h
+++ b/statemachine/VirtualLogStateMachine.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "log/include/VirtualLog.h"
 #include "log/proto/LogEntry.pb.h"
+#include "statemachine/NullStateMachine.h"
 #include "statemachine/include/StateMachine.h"
 
 namespace rk::projects::state_machine {
@@ -13,9 +14,12 @@ using namespace rk::projects::durable_log;
 template <typename R>
 class VirtualLogStateMachine : public StateMachine<LogEntry_1, R> {
 public:
-  explicit VirtualLogStateMachine(std::shared_ptr<VirtualLog> virtualLog)
-      : virtualLog_{std::move(virtualLog)}, upstreamStateMachine_{nullptr},
-        lastAppliedLogId_{0} {}
+  explicit VirtualLogStateMachine(std::shared_ptr<VirtualLog> virtualLog,
+                                  LogId lastAppliedLogId = 0)
+      : virtualLog_{std::move(virtualLog)},
+        upstreamStateMachine_{
+            std::make_shared<NullStateMachine<LogEntry_1, R>>()},
+        lastAppliedLogId_{lastAppliedLogId} {}
 
   coro<R> append(LogEntry_1 t) override {
     auto logId = co_await virtualLog_->append(t.SerializeAsString());

--- a/statemachine/include/StateMachine.h
+++ b/statemachine/include/StateMachine.h
@@ -25,7 +25,7 @@ public:
   virtual void setApplicator(std::shared_ptr<Applicator<T, R>> applicator) = 0;
 
   virtual void setUpstreamStateMachine(
-      std::shared_ptr<StateMachine<T, R>> upstreamStateMachine) {}
+      std::shared_ptr<StateMachine<T, R>> upstreamStateMachine) = 0;
 };
 
 } // namespace rk::projects::state_machine


### PR DESCRIPTION
**Background**: NullStateMachine throws runtime_error for all operations. It is a sane default when stateMachine cannot be set during constructor. 