### PR TITLE
Fix width of colId, tableid, dbid, indexid

### DIFF
--- a/applications/mydb/backend/Common.h
+++ b/applications/mydb/backend/Common.h
@@ -10,10 +10,22 @@
 namespace rk::projects::mydb {
 using namespace internal;
 
+template <typename Enumeration>
+auto enumToInteger(Enumeration const value) ->
+    typename std::underlying_type<Enumeration>::type {
+  return static_cast<typename std::underlying_type<Enumeration>::type>(value);
+}
+
 struct TableSchemaType {
   using DbIdType = decltype(Database{}.id());
   using TableIdType = decltype(Table{}.id());
   using ColumnIdType = decltype(Column{}.id());
+};
+
+enum class LockType : std::uint32_t {
+  NO_LOCK = 0,
+  WRITE_LOCK = 1,
+  READ_LOCK = 2,
 };
 
 namespace {

--- a/applications/mydb/backend/Db.h
+++ b/applications/mydb/backend/Db.h
@@ -29,6 +29,9 @@ class Db {
   client::TableRows scanDatabase(const client::ScanTableRequest* request);
 
  private:
+  client::Condition addConditionToCheckWriteLock(client::Condition condition);
+
+ private:
   std::shared_ptr<SchemaStore> schemaStore_;
   std::shared_ptr<QueryExecutor> queryExecutor_;
   TableSchemaType::DbIdType dbIds_;

--- a/applications/mydb/backend/DbDefaults.cc
+++ b/applications/mydb/backend/DbDefaults.cc
@@ -1,0 +1,22 @@
+//
+// Created by Rahul  Kushwaha on 1/12/24.
+//
+
+#include "applications/mydb/backend/DbDefaults.h"
+
+namespace rk::projects::mydb {
+
+std::vector<internal::Column> getTableDefaultColumns() {
+  std::vector<internal::Column> defaultColumns{};
+
+  internal::Column lockModeCol{};
+  lockModeCol.set_name(TableDefaultColumns::LOCK_MODE_NAME);
+  lockModeCol.set_column_type(internal::Column_COLUMN_TYPE_INT64);
+  lockModeCol.set_id(TableDefaultColumns::LOCK_MODE_COL_ID);
+
+  defaultColumns.emplace_back(std::move(lockModeCol));
+
+  return defaultColumns;
+}
+
+}  // namespace rk::projects::mydb

--- a/applications/mydb/backend/DbDefaults.h
+++ b/applications/mydb/backend/DbDefaults.h
@@ -8,19 +8,10 @@
 namespace rk::projects::mydb {
 
 struct TableDefaultColumns {
-  static constexpr std::string LOCK_MODE = "__internal__lock_mode";
+  static constexpr char* LOCK_MODE_NAME = "__internal__lock_mode";
+  static constexpr std::uint32_t LOCK_MODE_COL_ID = 1001;
 };
 
-std::vector<internal::Column> getTableDefaultColumns() {
-  std::vector<internal::Column> defaultColumns{};
-
-  internal::Column lockModeCol{};
-  lockModeCol.set_name(TableDefaultColumns::LOCK_MODE);
-  lockModeCol.set_column_type(internal::Column_COLUMN_TYPE_INT64);
-
-  defaultColumns.emplace_back(std::move(lockModeCol));
-
-  return defaultColumns;
-}
+std::vector<internal::Column> getTableDefaultColumns();
 
 }  // namespace rk::projects::mydb

--- a/applications/mydb/backend/Errors.h
+++ b/applications/mydb/backend/Errors.h
@@ -2,6 +2,8 @@
 // Created by Rahul  Kushwaha on 1/12/24.
 //
 #pragma once
+
+#include "applications/mydb/backend/Common.h"
 #include "fmt/format.h"
 
 #include <stdexcept>
@@ -21,16 +23,10 @@ enum class ErrorCode {
   TABLE_ALREADY_EXISTS = 6,
 };
 
-template <typename Enumeration>
-auto as_integer(Enumeration const value) ->
-    typename std::underlying_type<Enumeration>::type {
-  return static_cast<typename std::underlying_type<Enumeration>::type>(value);
-}
-
 struct DbError final : public std::runtime_error {
   explicit DbError(ErrorCode errorCode)
       : runtime_error(fmt::format("error encountered. error-code: {}",
-                                  as_integer(errorCode))),
+                                  enumToInteger(errorCode))),
         errorCode_{errorCode} {}
 
   ErrorCode errorCode_;

--- a/applications/mydb/backend/QueryPlanner.cc
+++ b/applications/mydb/backend/QueryPlanner.cc
@@ -48,20 +48,26 @@ cp::Expression QueryPlanner::parseCondition(
     return parseUnaryCondition(internalTable, condition.unary_condition());
   }
 
-  auto left = parseCondition(internalTable, condition.binary_condition().c1());
-  auto right = parseCondition(internalTable, condition.binary_condition().c2());
+  if (condition.has_binary_condition()) {
+    auto left =
+        parseCondition(internalTable, condition.binary_condition().c1());
+    auto right =
+        parseCondition(internalTable, condition.binary_condition().c2());
 
-  switch (condition.binary_condition().op()) {
-    case client::AND:
-      filterExpression = cp::and_(left, right);
-      break;
-    case client::OR:
-      filterExpression = cp::or_(left, right);
-      break;
-    default:
-      assert(false && "unknown logical joining condition");
+    switch (condition.binary_condition().op()) {
+      case client::AND:
+        filterExpression = cp::and_(left, right);
+        break;
+      case client::OR:
+        filterExpression = cp::or_(left, right);
+        break;
+      default:
+        assert(false && "unknown logical joining condition");
+    }
+    return filterExpression;
   }
-  return filterExpression;
+
+  return cp::literal(true);
 }
 
 cp::Expression QueryPlanner::parseUnaryCondition(

--- a/applications/mydb/backend/RequestTransformer.h
+++ b/applications/mydb/backend/RequestTransformer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "applications/mydb/backend/Common.h"
+#include "applications/mydb/backend/DbDefaults.h"
 #include "applications/mydb/backend/RowSerializer.h"
 #include "applications/mydb/backend/TableRow.h"
 #include "applications/mydb/client/proto/db.pb.h"
@@ -265,6 +266,9 @@ class Transformer {
 
       table.mutable_columns()->Add(std::move(column));
     }
+
+    auto defaultCols = getTableDefaultColumns();
+    table.mutable_columns()->Add(defaultCols.begin(), defaultCols.end());
 
     auto& primaryKeyIndex = *table.mutable_primary_key_index();
     primaryKeyIndex.set_id(0);

--- a/applications/mydb/backend/tests/KeySerializerTests.cc
+++ b/applications/mydb/backend/tests/KeySerializerTests.cc
@@ -85,6 +85,6 @@ TEST_P(PrefixTestsSuite, parseKeyString) {
   ASSERT_EQ(std::stoi(keyFragments.primaryIndex->values[0]), 5000);
 }
 
-INSTANTIATE_TEST_SUITE_P(PrefixTestSuite, PrefixTestsSuite,
+INSTANTIATE_TEST_SUITE_P(PrefixTestSuiteParameterizedTests, PrefixTestsSuite,
                          testing::Values(getMetaTables()));
 }  // namespace rk::projects::mydb

--- a/applications/mydb/backend/tests/QueryExecutorTests.cc
+++ b/applications/mydb/backend/tests/QueryExecutorTests.cc
@@ -41,7 +41,7 @@ TEST_F(QueryExecutorTests, scanTableUsingPrimaryIndex) {
 }
 
 TEST_F(QueryExecutorTests, scanTableUsingSecondaryIndex) {
-  auto internalTable = test_utils::getInternalTable(1, 0, 5, 1, 1, 1);
+  auto internalTable = test_utils::getInternalTable(1, 5, 5, 1, 1, 1);
 
   queryExecutor_->insert(internalTable);
 

--- a/applications/mydb/backend/tests/QueryPlannerTest.cc
+++ b/applications/mydb/backend/tests/QueryPlannerTest.cc
@@ -27,7 +27,7 @@ class QueryPlannerTests : public persistence::RocksTestFixture {
 };
 
 TEST_F(QueryPlannerTests, scanTableUsingPrimaryIndexWithIntUnaryCondition) {
-  auto internalTable = test_utils::getInternalTable(10, 5, 1, 1, 1, 1);
+  auto internalTable = test_utils::getInternalTable(10, 5, 5, 1, 1, 1);
   queryExecutor_->insert(internalTable);
   testIntUnaryCondition(client::IntCondition_Operation_GT, 5, 4, internalTable);
   testIntUnaryCondition(client::IntCondition_Operation_GEQ, 5, 5,
@@ -39,29 +39,29 @@ TEST_F(QueryPlannerTests, scanTableUsingPrimaryIndexWithIntUnaryCondition) {
 }
 
 TEST_F(QueryPlannerTests, scanTableUsingPrimaryKeyWithBinaryCondition) {
-  auto internalTable = test_utils::getInternalTable(10, 5, 0, 1, 1, 1);
+  auto internalTable = test_utils::getInternalTable(10, 5, 5, 1, 1, 1);
   queryExecutor_->insert(internalTable);
   auto formattedTable = FormatTable::format(internalTable).str();
   LOG(INFO) << formattedTable;
 
-  auto intCondtion1 = client::IntCondition{};
-  intCondtion1.set_col_name(internalTable.schema->getColumnName(0));
-  intCondtion1.set_op(client::IntCondition_Operation_GT);
-  intCondtion1.set_value(2);
+  auto intCondition1 = client::IntCondition{};
+  intCondition1.set_col_name(internalTable.schema->getColumnName(0));
+  intCondition1.set_op(client::IntCondition_Operation_GT);
+  intCondition1.set_value(2);
 
   auto unaryCondition1 = client::UnaryCondition{};
-  unaryCondition1.mutable_int_condition()->CopyFrom(intCondtion1);
+  unaryCondition1.mutable_int_condition()->CopyFrom(intCondition1);
 
   auto condition1 = client::Condition{};
   condition1.mutable_unary_condition()->CopyFrom(unaryCondition1);
 
-  auto intCondtion2 = client::IntCondition{};
-  intCondtion2.set_col_name(internalTable.schema->getColumnName(1));
-  intCondtion2.set_op(client::IntCondition_Operation_LT);
-  intCondtion2.set_value(16);
+  auto intCondition2 = client::IntCondition{};
+  intCondition2.set_col_name(internalTable.schema->getColumnName(1));
+  intCondition2.set_op(client::IntCondition_Operation_LT);
+  intCondition2.set_value(16);
 
   auto unaryCondition2 = client::UnaryCondition{};
-  unaryCondition2.mutable_int_condition()->CopyFrom(intCondtion2);
+  unaryCondition2.mutable_int_condition()->CopyFrom(intCondition2);
 
   auto condition2 = client::Condition{};
   condition2.mutable_unary_condition()->CopyFrom(unaryCondition2);

--- a/cmake/source_list.cmake
+++ b/cmake/source_list.cmake
@@ -126,6 +126,7 @@ set(
         applications/mydb/backend/Common.h
         applications/mydb/backend/Db.cc
         applications/mydb/backend/Db.h
+        applications/mydb/backend/DbDefaults.cc
         applications/mydb/backend/DbDefaults.h
         applications/mydb/backend/Errors.h
         applications/mydb/backend/KeySerializer.cc


### PR DESCRIPTION
**Background**: 
The current data serialization format does not produce rows of constant width, and that can mess up sort order and other stuff as well. 

Secondly, add an internal column to each row that will help track the lock status. This will be utilized during 2PC. 

**Implementation**: 
1. Create a function `pad` that adds zeros for make each id(tableId, colId, indexId) constant width. 
2. Makes changes to add default internal columns(__internal__lock_mode). This will help track the lock status of the row. 
3. Change `updateRow` method to check for row lock. 